### PR TITLE
Add default stubs directory

### DIFF
--- a/src/Endpoints/Laravel/LaravelMaker.php
+++ b/src/Endpoints/Laravel/LaravelMaker.php
@@ -82,6 +82,7 @@ class LaravelMaker extends Maker
     protected function stub($name)
     {
         $dir = collect([
+            'stubs',
             'vendor/laravel/framework/src/Illuminate/Foundation/Console/stubs',
             'vendor/laravel/framework/src/Illuminate/Routing/Console/stubs',
             'vendor/laravel/framework/src/Illuminate/Foundation/Console/stubs',


### PR DESCRIPTION
It checks inside the default `stubs` folder laravel creates via `php artisan stub:publish`, in order to customize stub files.