### PR TITLE
Require nikic/php-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
         }
     ],
     "require": {
-        "doctrine/dbal": "^2.9 || ^3.0"
+        "doctrine/dbal": "^2.9 || ^3.0",
+        "nikic/php-parser": "^4.11",
     },
     "require-dev": {
         "laravel/laravel": "^6.0 || ^7.0 || ^8.0",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
         "phpunit/phpunit": "^8.0 || ^9.5",
-        "nikic/php-parser": "^4.11",
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
     ],
     "require": {
         "doctrine/dbal": "^2.9 || ^3.0",
-        "nikic/php-parser": "^4.11",
+        "nikic/php-parser": "^4.11"
     },
     "require-dev": {
         "laravel/laravel": "^6.0 || ^7.0 || ^8.0",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
-        "phpunit/phpunit": "^8.0 || ^9.5",
+        "phpunit/phpunit": "^8.0 || ^9.5"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "require-dev": {
         "laravel/laravel": "^6.0 || ^7.0 || ^8.0",
         "orchestra/testbench": "^4.0 || ^5.0 || ^6.0",
-        "phpunit/phpunit": "^8.0 || ^9.5"
+        "phpunit/phpunit": "^8.0 || ^9.5",
+        "nikic/php-parser": "^4.11",
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
It looks like this package works without the explicit requirement because `phpunit` requires it, but if you wanted to use not in dev, it breaks. It feels like best practice to require the packages you use explicitly.

You could also move `phpunit` to `require` instead of `require-dev` I suppose.