### PR TITLE
Add teststubs for pretty printing

### DIFF
--- a/tests/Feature/PrettyPrintTest.php
+++ b/tests/Feature/PrettyPrintTest.php
@@ -1,0 +1,42 @@
+<?php
+
+class PrettyPrintTest extends Archetype\Tests\TestCase
+{	
+    public function test_arrays_are_beutiful_when_loaded_and_rendered()
+    {
+		$output = LaravelFile::user()->render();
+        $this->assertMultilineArray('fillable', $output);
+    }
+
+    public function test_arrays_are_beutiful_when_loaded_modified_and_rendered()
+    {
+		$this->markTestIncomplete();
+
+		$output = LaravelFile::user()
+			->add('also')->to()->property('fillable')
+			->render();
+
+        $this->assertMultilineArray('fillable', $output);
+    }	
+
+    public function test_arrays_are_beutiful_when_created_and_rendered()
+    {
+		$this->markTestIncomplete();
+
+		$output = PHPFile::class('FillableClass')
+			->add()->property('fillable', ['first', 'second', 'third'])
+			->render();
+        
+		$this->assertMultilineArray('ints', $output);
+    }
+	
+    public function test_arrays_are_beutiful_when_empty()
+    {
+		$this->markTestIncomplete();
+    }	
+
+    public function test_arrays_have_trailing_comma_after_last_item()
+    {
+		$this->markTestIncomplete();
+    }		
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -62,4 +62,15 @@ class TestCase extends \Orchestra\Testbench\TestCase
             File::deleteDirectory($directory);
         });
     }
+
+	public function assertMultilineArray($name, $output) {
+		preg_match("/$name \= (\[[^\;]*)/s", $output, $matches);
+		$code = $matches[1];
+		$commas = substr_count($code, ',');
+		
+		$this->assertEquals(
+			substr_count($code, PHP_EOL),
+			$commas + 1
+		);
+	}
 }


### PR DESCRIPTION
The formatting for array properties is off. This PR adds tests but does not solve the issues.

```php
class User {
    // When loading existing and render. Good!
    protected $fillable = [
        'name',
        'email',
        'password',
    ];
}

class User {
    // When loading, modifying and render. Bad!
    protected $fillable = ['name', 'email', 'password', 'another'];
}

class User {
    // When creating and render. Bad!
    protected $fillable = ['name', 'email', 'password'];
}

```