### PR TITLE
Add Multiline Arrays

### DIFF
--- a/src/Support/PSR2PrettyPrinter.php
+++ b/src/Support/PSR2PrettyPrinter.php
@@ -28,8 +28,6 @@ class PSR2PrettyPrinter extends StandardPrettyPrinter
     protected function pStmt_ClassMethod(ClassMethod $node)
     {
         $comments = $node->getComments();
-        
-
 
         $ln = $comments ? '' : $this->nl;
 
@@ -45,8 +43,9 @@ class PSR2PrettyPrinter extends StandardPrettyPrinter
 
     protected function pExpr_Array(Array_ $node)
     {
-        // Fix proper multiline here
-        return parent::pExpr_array($node);
+		$stmts = $this->pCommaSeparatedMultiline($node->items, true);
+		$lineBreaked = $stmts ? $stmts . $this->nl : $stmts;
+		return "[{$lineBreaked}]";
     }
 
     /**
@@ -121,29 +120,6 @@ class PSR2PrettyPrinter extends StandardPrettyPrinter
         }
 
         return $result;
-    }
-    
-    protected function pMaybeMultiline(array $nodes, bool $trailingComma = false)
-    {
-        if (!$this->hasNodeWithComments($nodes)) {
-            return $this->pCommaSeparated($nodes);
-        } else {
-            return $this->pCommaSeparatedMultiline($nodes, $trailingComma) . $this->nl;
-        }
-    }
-    
-    /**
-     * @param Node[] $nodes
-     * @return bool
-     */
-    protected function hasNodeWithComments(array $nodes)
-    {
-        foreach ($nodes as $node) {
-            if ($node && $node->getComments()) {
-                return true;
-            }
-        }
-        return false;
     }
     
     /**

--- a/tests/Feature/PrettyPrintTest.php
+++ b/tests/Feature/PrettyPrintTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Archetype\Facades\LaravelFile;
+use Archetype\Facades\PHPFile;
+
 class PrettyPrintTest extends Archetype\Tests\TestCase
 {	
     public function test_arrays_are_beutiful_when_loaded_and_rendered()
@@ -10,8 +13,6 @@ class PrettyPrintTest extends Archetype\Tests\TestCase
 
     public function test_arrays_are_beutiful_when_loaded_modified_and_rendered()
     {
-		$this->markTestIncomplete();
-
 		$output = LaravelFile::user()
 			->add('also')->to()->property('fillable')
 			->render();
@@ -19,20 +20,22 @@ class PrettyPrintTest extends Archetype\Tests\TestCase
         $this->assertMultilineArray('fillable', $output);
     }	
 
-    public function test_arrays_are_beutiful_when_created_and_rendered()
+    public function test_arrays_are_beautiful_when_created_and_rendered()
     {
-		$this->markTestIncomplete();
-
 		$output = PHPFile::class('FillableClass')
 			->add()->property('fillable', ['first', 'second', 'third'])
 			->render();
-        
-		$this->assertMultilineArray('ints', $output);
+
+		$this->assertMultilineArray('fillable', $output);
     }
 	
     public function test_arrays_are_beutiful_when_empty()
     {
-		$this->markTestIncomplete();
+		$output = PHPFile::class('FillableClass')
+			->property('fillable', [])
+			->render();
+		
+		$this->assertSingleLineEmptyArray('fillable', $output);
     }	
 
     public function test_arrays_have_trailing_comma_after_last_item()

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -73,4 +73,8 @@ class TestCase extends \Orchestra\Testbench\TestCase
 			$commas + 1
 		);
 	}
+
+	public function assertSingleLineEmptyArray($name, $output) {
+		$this->assertMatchesRegularExpression("/$name \= (\[\];]*)/s", $output);
+	}	
 }


### PR DESCRIPTION
Finally, arrays formmating with newlines. Works for both new, loaded and modified code.

Examples:
```php
class Finally
{
    protected $empty = [];
    
    protected $one = [
        'one',
    ];
    
    protected $moreThanOne = [
        'one',
        'two',
    ];
}
```

Continuation of #30. Fixes formatting discussion in: #22