### PR TITLE
Introducing TestablePHPFile

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,6 @@
     },
     "extra": {
         "laravel": {
-            "aliases": {
-                "LaravelFile": "Archetype\\Facades\\LaravelFile",
-                "PHPFile": "Archetype\\Facades\\PHPFile"
-            },
             "dont-discover": [],
             "providers": [
                 "Archetype\\ServiceProvider"

--- a/src/Support/RecursiveFileSearch.php
+++ b/src/Support/RecursiveFileSearch.php
@@ -2,21 +2,9 @@
 
 namespace Archetype\Support;
 
-use Illuminate\Support\Str;
-use Archetype\Endpoints\EndpointProvider;
-use Archetype\Support\PSR2PrettyPrinter;
-use PhpParser\ParserFactory;
-use Illuminate\Support\Facades\Storage;
-use Error;
-use UnexpectedValueException;
-use Archetype\Traits\HasOperators;
-use ReflectionClass;
-use ReflectionMethod;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
 use RecursiveCallbackFilterIterator;
-use InvalidArgumentException;
-use LaravelFile;
 
 class RecursiveFileSearch
 {

--- a/src/Support/Snippet.php
+++ b/src/Support/Snippet.php
@@ -2,16 +2,11 @@
 
 namespace Archetype\Support;
 
+use Archetype\Facades\PHPFile;
 use PhpParser\Node\Stmt\ClassMethod;
-use PhpParser\Node\Stmt\Property;
 use PhpParser\NodeFinder;
-use PhpParser\Node\Identifier;
-use PhpParser\Node\Name\FullyQualified;
-use PhpParser\Node\Name;
 use PhpParser\JsonDecoder;
 
-use PHPFile;
-use InvalidArgumentException;
 use Archetype\Support\AST\Visitors\FormattingRemover;
 
 class Snippet

--- a/src/Traits/HasIO.php
+++ b/src/Traits/HasIO.php
@@ -112,7 +112,7 @@ trait HasIO
         }
 
         $ast = $traverser->traverse($this->originalAst);
-        
+
         return $ast;
     }
 

--- a/tests/Feature/DuplicateEndpointTest.php
+++ b/tests/Feature/DuplicateEndpointTest.php
@@ -1,10 +1,9 @@
 <?php
 
-use Archetype\LaravelFile;
+use Archetype\Facades\LaravelFile;
 
 test('no duplicated endpoints', function() {
-	$endpoints = (new LaravelFile)
-		->endpointProviders()
+	$endpoints = LaravelFile::endpointProviders()
 		->map(function ($provider) {
 			return (new $provider())->getEndpoints();
 		})->flatten();

--- a/tests/Feature/DuplicateEndpointTest.php
+++ b/tests/Feature/DuplicateEndpointTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\LaravelFile;
 
-test('no_duplicated_endpoints', function() {
+test('no duplicated endpoints', function() {
 	$endpoints = (new LaravelFile)
 		->endpointProviders()
 		->map(function ($provider) {

--- a/tests/Feature/FilePathTest.php
+++ b/tests/Feature/FilePathTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-test('a_file_has_an_input_path', function() {
+test('a file has an input path', function() {
 	// relative
 	$file = PHPFile::load('app/Models/User.php');
 	$this->assertTrue(
@@ -17,7 +17,7 @@ test('a_file_has_an_input_path', function() {
 	);
 });
     
-test('a_file_has_a_filename', function() {
+test('a file has a filename', function() {
 	// relative
 	$file = PHPFile::load('app/Models/User.php');
 	$this->assertTrue(
@@ -32,7 +32,7 @@ test('a_file_has_a_filename', function() {
 	);
 });
     
-test('files_created_with_fromString_must_be_explicitly_named', function() {
+test('files created with fromString must be explicitly named', function() {
 	$file = PHPFile::fromString('<?php');
 
 	$this->expectException(TypeError::class);

--- a/tests/Feature/PrettyPrintTest.php
+++ b/tests/Feature/PrettyPrintTest.php
@@ -3,12 +3,12 @@
 use Archetype\Facades\LaravelFile;
 use Archetype\Facades\PHPFile;
 
-test('arrays_are_beutiful_when_loaded_and_rendered', function() {
+test('arrays are beutiful when loaded and rendered', function() {
 	$output = LaravelFile::user()->render();
 	$this->assertMultilineArray('fillable', $output);
 });
 
-test('arrays_are_beutiful_when_loaded_modified_and_rendered', function() {
+test('arrays are beutiful when loaded modified and rendered', function() {
 	$output = LaravelFile::user()
 		->add('also')->to()->property('fillable')
 		->render();
@@ -16,7 +16,7 @@ test('arrays_are_beutiful_when_loaded_modified_and_rendered', function() {
 	$this->assertMultilineArray('fillable', $output);
 });
 
-test('arrays_are_beautiful_when_created_and_rendered', function() {
+test('arrays are beautiful when created and rendered', function() {
 	$output = PHPFile::class('FillableClass')
 		->add()->property('fillable', ['first', 'second', 'third'])
 		->render();
@@ -24,7 +24,7 @@ test('arrays_are_beautiful_when_created_and_rendered', function() {
 	$this->assertMultilineArray('fillable', $output);
 });
 
-test('arrays_are_beutiful_when_empty', function() {
+test('arrays are beutiful when empty', function() {
 	$output = PHPFile::class('FillableClass')
 		->property('fillable', [])
 		->render();

--- a/tests/Feature/ReadWriteTest.php
+++ b/tests/Feature/ReadWriteTest.php
@@ -4,7 +4,7 @@ use Archetype\Facades\LaravelFile;
 use Archetype\Facades\PHPFile;
 use Illuminate\Support\Facades\Config;
 
-it('wont_see_debug_or_output_folders_because_they_are_removed_at_start_up', function() {
+it('wont see debug or output folders because they are removed at start up', function() {
 	$this->assertFalse(
 		is_dir(Config::get('archetype.roots.debug.root'))
 	);
@@ -14,7 +14,7 @@ it('wont_see_debug_or_output_folders_because_they_are_removed_at_start_up', func
 	);
 });
 
-it('can_load_php_files', function() {
+it('can load php files', function() {
 	$file = PHPFile::load('public/index.php');
 
 	$this->assertTrue(
@@ -22,7 +22,7 @@ it('can_load_php_files', function() {
 	);
 });
 
-it('can_load_files_with_absolute_path', function() {
+it('can load files with absolute path', function() {
 	$file = PHPFile::load(
 		base_path('vendor/ajthinking/archetype/src/snippets/relationships.php')
 	);
@@ -32,7 +32,7 @@ it('can_load_files_with_absolute_path', function() {
 	);
 });
 
-it('will_accept_forbidden_directories_when_explicitly_passed', function() {
+it('will accept forbidden directories when explicitly passed', function() {
 	$file = PHPFile::in(
 		'vendor/ajthinking/archetype/src/snippets'
 	)->get()->first();
@@ -42,7 +42,7 @@ it('will_accept_forbidden_directories_when_explicitly_passed', function() {
 	);
 });
 
-it('can_also_load_laravel_specific_files', function() {
+it('can also load laravel specific files', function() {
 	$file = LaravelFile::load('app/Models/User.php');
 
 	$this->assertInstanceOf(
@@ -51,7 +51,7 @@ it('can_also_load_laravel_specific_files', function() {
 	);
 });
 
-it('can_write_to_default_location', function() {
+it('can write to default location', function() {
 	// default save location is in .output when in development mode
 	LaravelFile::load('app/Models/User.php')->save();
 	

--- a/tests/Feature/ReadWriteTest.php
+++ b/tests/Feature/ReadWriteTest.php
@@ -1,7 +1,8 @@
 <?php
 
 use Archetype\Facades\LaravelFile;
-use Archetype\Facades\PHPFile;
+use Archetype\Support\Exceptions\FileParseError;
+use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;
 use Illuminate\Support\Facades\Config;
 
 it('wont see debug or output folders because they are removed at start up', function() {
@@ -18,7 +19,7 @@ it('can load php files', function() {
 	$file = PHPFile::load('public/index.php');
 
 	$this->assertTrue(
-		get_class($file) === 'Archetype\PHPFile'
+		get_class($file) === \Archetype\Tests\Support\TestablePHPFile::class
 	);
 });
 
@@ -28,7 +29,7 @@ it('can load files with absolute path', function() {
 	);
 
 	$this->assertTrue(
-		get_class($file) === 'Archetype\PHPFile'
+		get_class($file) === \Archetype\Tests\Support\TestablePHPFile::class
 	);
 });
 
@@ -38,7 +39,7 @@ it('will accept forbidden directories when explicitly passed', function() {
 	)->get()->first();
 
 	$this->assertTrue(
-		get_class($file) === 'Archetype\PHPFile'
+		get_class($file) === \Archetype\Tests\Support\TestablePHPFile::class
 	);
 });
 
@@ -65,4 +66,15 @@ it('can write to default location', function() {
 	$this->assertTrue(
 		is_file(Config::get('archetype.roots.debug.root') . '/app/Models/User.php')
 	);
+});
+
+it('will throw error if code cant be parsed', function() {
+	$this->expectException(FileParseError::class);
+
+	PHPFile::fromString("<?php bad code");
+});
+
+it('can ensure code is valid', function() {
+	PHPFile::fromString('<?php $ok = 1;')
+		->assertValidPhp();
 });

--- a/tests/Feature/ReadmeTest.php
+++ b/tests/Feature/ReadmeTest.php
@@ -1,11 +1,12 @@
 <?php
 
 use Archetype\Facades\LaravelFile;
+use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;
 
 /**
  * Example from: https://github.com/ajthinking/archetype#laravelfile-readwrite-api
  */
-it('can_edit_files_and_produce_valid_ast', function() {
+it('can edit files and produce valid ast', function() {
 	$file = LaravelFile::user()
 		->add()->use(['App\Traits\Dumpable', 'App\Contracts\PlayerInterface'])
 		->add()->implements('PlayerInterface')

--- a/tests/Support/Facades/TestablePHPFile.php
+++ b/tests/Support/Facades/TestablePHPFile.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Archetype\Tests\Support\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class TestablePHPFile extends Facade
+{
+    protected static function getFacadeAccessor()
+    {
+        return 'TestablePHPFile';
+    }
+}

--- a/tests/Support/Factories/TestablePHPFileFactory.php
+++ b/tests/Support/Factories/TestablePHPFileFactory.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Archetype\Tests\Support\Factories;
+
+use Archetype\Factories\PHPFileFactory;
+use Archetype\Tests\Support\TestablePHPFile;
+
+class TestablePHPFileFactory extends PHPFileFactory
+{
+    const FILE_TYPE = TestablePHPFile::class;
+}

--- a/tests/Support/TestablePHPFile.php
+++ b/tests/Support/TestablePHPFile.php
@@ -6,6 +6,7 @@ use Archetype\PHPFile;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertInstanceOf;
 use function PHPUnit\Framework\assertStringContainsString;
 
 class TestablePHPFile extends PHPFile
@@ -65,6 +66,16 @@ class TestablePHPFile extends PHPFile
 		assertStringContainsString(
 			$string,
 			$this->render()
+		);
+
+		return $this;
+	}
+
+	public function assertValidPhp()
+	{
+		assertInstanceOf(
+			TestablePHPFile::class,
+			PHPFile::fromString($this->render())
 		);
 
 		return $this;

--- a/tests/Support/TestablePHPFile.php
+++ b/tests/Support/TestablePHPFile.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Archetype\Tests\Support;
+
+use Archetype\PHPFile;
+
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertFalse;
+use function PHPUnit\Framework\assertStringContainsString;
+
+class TestablePHPFile extends PHPFile
+{
+	public function assertClassConstant(string $name, $value)
+	{
+		assertEquals($this->classConstant($name), $value);
+
+		return $this;
+	}
+
+	public function assertNoClassConstant(string $name)
+	{
+		$exists = $this->astQuery()
+            ->class()
+            ->classConst()
+            ->where(function ($query) use ($name) {
+                return $query->const()
+					->where('name->name', $name)
+                    ->get()
+					->isNotEmpty();
+            })->get()
+			->isNotEmpty();
+
+		assertFalse($exists);
+
+		return $this;
+	}
+
+	public function assertNoProperty(string $name)
+	{
+		$exists = $this->astQuery()
+            ->class()
+            ->property()
+            ->where(function ($query) use ($name) {
+                return $query->propertyProperty()
+					->where('name->name', $name)
+                    ->get()
+					->isNotEmpty();
+            })->get()
+			->isNotEmpty();
+
+		assertFalse($exists);
+
+		return $this;
+	}
+
+	public function assertProperty($name, $value)
+	{
+		assertEquals($this->property($name), $value);
+		
+		return $this;
+	}
+
+	public function assertContains(string $string)
+	{
+		assertStringContainsString(
+			$string,
+			$this->render()
+		);
+
+		return $this;
+	}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -28,14 +28,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
         $app['config']->set('archetype.roots.output.root', base_path('.output'));
     }
 
-    protected function getPackageAliases($app)
-    {
-        return [
-          'LaravelFile' => \Archetype\Facades\LaravelFile::class,
-          'PHPFile' => \Archetype\Facades\PHPFile::class,
-        ];
-    }
-
     protected function getPackageProviders($app)
     {
         return [\Archetype\ServiceProvider::class];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Archetype\Tests;
 
+use Archetype\Tests\Support\TestablePHPFileFactory;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\File;
 
@@ -13,6 +14,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
 
         $this->cleanupDirectories();
         $this->setupLaravelDirectories();
+		$this->registerTestFacades();
     }
 
     protected function tearDown(): void
@@ -32,6 +34,13 @@ class TestCase extends \Orchestra\Testbench\TestCase
     {
         return [\Archetype\ServiceProvider::class];
     }
+
+	protected function registerTestFacades()
+	{
+        app()->bind('TestablePHPFile', function () {
+            return app()->make(Support\Factories\TestablePHPFileFactory::class);
+        });
+	}
 
     protected function setupLaravelDirectories()
     {

--- a/tests/Unit/Endpoints/Laravel/LaravelFileQueryBuilderTest.php
+++ b/tests/Unit/Endpoints/Laravel/LaravelFileQueryBuilderTest.php
@@ -2,21 +2,21 @@
 
 use Archetype\Facades\LaravelFile;
 
-it('can_scope_on_models', function() {
+it('can scope on models', function() {
 	$this->assertCount(
 		1,
 		LaravelFile::models()->get()
 	);
 });
 
-it('can_scope_on_controllers', function() {
+it('can scope on controllers', function() {
 	$this->assertCount(
 		1,
 		LaravelFile::controllers()->get()
 	);
 });
 
-it('can_get_user', function() {
+it('can get user', function() {
 	$this->assertTrue(
 		get_class(LaravelFile::load('app/Models/User.php')) === 'Archetype\LaravelFile'
 	);

--- a/tests/Unit/Endpoints/Laravel/LaravelPropertyTest.php
+++ b/tests/Unit/Endpoints/Laravel/LaravelPropertyTest.php
@@ -2,25 +2,25 @@
 
 use Archetype\Facades\LaravelFile;
 
-it('can_retrieve_fillables', function() {
+it('can retrieve fillables', function() {
 	$this->assertTrue(
 		LaravelFile::load('app/Models/User.php')->fillable() == ['name', 'email', 'password',]
 	);
 });
 
-it('can_retrieve_hidden', function() {
+it('can retrieve hidden', function() {
 	$this->assertTrue(
 		LaravelFile::load('app/Models/User.php')->hidden() == ['password', 'remember_token',]
 	);
 });
 
-it('wont_break_if_properties_are_missing', function() {
+it('wont break if properties are missing', function() {
 	$this->assertNull(
 		LaravelFile::load('public/index.php')->hidden()
 	);
 });
 
-it('will_assume_array_if_we_are_inserting_on_a_new_hidden_property', function() {
+it('will assume array if we are inserting on a new hidden property', function() {
 	$hidden = LaravelFile::load('app/Models/User.php')
 		->remove()->hidden()
 		->hidden('ghost')->hidden();
@@ -40,14 +40,14 @@ it('will_assume_array_if_we_are_inserting_on_a_new_hidden_property', function() 
 	);
 });
 
-it('can_set_fillables', function() {
+it('can set fillables', function() {
 	$this->assertEquals(
 		LaravelFile::load('app/Models/User.php')->fillable(['guns', 'roses'])->fillable(),
 		['guns', 'roses',]
 	);
 });
 
-it('can_add_fillables', function() {
+it('can add fillables', function() {
 	$this->assertEquals(
 		LaravelFile::load('app/Models/User.php')
 			->fillable(['guns', 'roses'])
@@ -57,14 +57,14 @@ it('can_add_fillables', function() {
 	);
 });
 
-it('can_set_hidden', function() {
+it('can set hidden', function() {
 	$this->assertEquals(
 		LaravelFile::load('app/Models/User.php')->hidden(['metallica', 'ozzy'])->hidden(),
 		['metallica', 'ozzy',]
 	);
 });
 
-it('can_use_setter_on_associative_arrays', function() {
+it('can use setter on associative arrays', function() {
 	$output = LaravelFile::load('app/Models/User.php')
 		->casts(['free' => 'bird'])
 		->casts();
@@ -74,7 +74,7 @@ it('can_use_setter_on_associative_arrays', function() {
 	], $output);
 });
 
-it('can_add_to_associative_arrays', function() {
+it('can add to associative arrays', function() {
 	$output = LaravelFile::load('app/Models/User.php')
 		->add()->casts(['free' => 'bird'])
 		->casts();
@@ -85,7 +85,7 @@ it('can_add_to_associative_arrays', function() {
 	], $output);
 });
 
-it('can_empty_associative_arrays', function() {
+it('can empty associative arrays', function() {
 	$output = LaravelFile::load('app/Models/User.php')
 		->empty()->casts()
 		->casts();

--- a/tests/Unit/Endpoints/Laravel/RelationshipsTest.php
+++ b/tests/Unit/Endpoints/Laravel/RelationshipsTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\LaravelFile;
 
-it('can_insert_belongs_to_methods', function () {
+it('can insert belongs to methods', function () {
 	$file = LaravelFile::load('app/Models/User.php');
 	$file->belongsTo(['App\Department']);
 
@@ -12,7 +12,7 @@ it('can_insert_belongs_to_methods', function () {
 	);
 });
 
-it('can_insert_belongs_to_many_methods', function () {
+it('can insert belongs to many methods', function () {
 	$file = LaravelFile::load('app/Models/User.php');
 	$file->belongsToMany(['App\Visit', 'App\\Purchase']);
 
@@ -22,7 +22,7 @@ it('can_insert_belongs_to_many_methods', function () {
 	);
 });
     
-it('can_also_use_string_as_argument', function () {
+it('can also use string as argument', function () {
 	$file = LaravelFile::load('app/Models/User.php');
 	$file->belongsToMany('App\Visit');
 
@@ -32,7 +32,7 @@ it('can_also_use_string_as_argument', function () {
 	);
 });
     
-it('can_insert_has_many_methods', function () {
+it('can insert HAS_MANY_METHODs', function () {
 	$file = LaravelFile::load('app/Models/User.php');
 	$file->hasMany(['App\Gun', 'App\Rose']);
 
@@ -47,7 +47,7 @@ it('can_insert_has_many_methods', function () {
 	);
 });
     
-it('can_insert_has_one_methods', function () {
+it('can insert has one methods', function () {
 	$file = LaravelFile::load('app/Models/User.php');
 	$file->hasOne(['App\Phone']);
 
@@ -57,7 +57,7 @@ it('can_insert_has_one_methods', function () {
 	);
 });
 
-it('wont_overwrite_already_existing_method', function () {
+it('wont overwrite already existing method', function () {
 	$file = LaravelFile::load('app/Models/User.php')
 		->hasOne(['App\Phone'])
 		->hasOne(['App\Phone']);

--- a/tests/Unit/Endpoints/PHP/ClassConstantTest.php
+++ b/tests/Unit/Endpoints/PHP/ClassConstantTest.php
@@ -1,39 +1,27 @@
 <?php
 
-use Archetype\Facades\PHPFile;
+use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;
 
-it('can_get_a_class_constant', function() {
-	$this->assertEquals(
-		PHPFile::load('app/Providers/RouteServiceProvider.php')->classConstant('HOME'),
-		'/home'
-	);
+it('can get a class constant', function() {
+	PHPFile::load('app/Providers/RouteServiceProvider.php')
+		->assertClassConstant('HOME', '/home');
 });
 
-it('can_update_existing_class_constants', function() {
-        $this->assertEquals(
-            PHPFile::load('app/Providers/RouteServiceProvider.php')
-			->classConstant('HOME', '/new_home')
-			->classConstant('HOME'),
-		'/new_home'
-	);
+it('can update existing class constants', function() {
+	PHPFile::load('app/Providers/RouteServiceProvider.php')
+		->classConstant('HOME', '/new_home')
+		->assertClassConstant('HOME', '/new_home');
 });
 
-it('can_create_a_new_class_constant', function() {
-        $constant = PHPFile::load('app/Models/User.php')
-            ->classConstant('BRAND_NEW', 'it will work')
-            ->classConstant('BRAND_NEW');
-
-	$this->assertEquals(
-		$constant,
-		'it will work'
-	);
+it('can create a new class constant', function() {
+	PHPFile::load('app/Models/User.php')
+		->classConstant('BRAND_NEW', 'it will work')
+		->assertClassConstant('BRAND_NEW', 'it will work');
 });
 
-it('can_remove_an_existing_class_constant', function() {
-		$this->assertNull(
-			PHPFile::make()->class('Dummy')
-			->classConstant('MSG', 'hi')
-			->remove()->classConstant('MSG')
-			->classConstant('MSG')
-	);		
+it('can remove an existing class constant', function() {
+	PHPFile::make()->class('Dummy')
+		->classConstant('MSG', 'hi')
+		->remove()->classConstant('MSG')
+		->assertNoClassConstant('MSG');		
 });

--- a/tests/Unit/Endpoints/PHP/ClassExtendsTest.php
+++ b/tests/Unit/Endpoints/PHP/ClassExtendsTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_retrieve_class_extends', function() {
+it('can retrieve class extends', function() {
 	$file = PHPFile::load('app/Models/User.php');
 
 	$this->assertTrue(
@@ -10,7 +10,7 @@ it('can_retrieve_class_extends', function() {
 	);
 });
 
-it('can_set_class_extends', function() {
+it('can set class extends', function() {
 	$file = PHPFile::load('app/Models/User.php')->extends("My\BaseClass");
 
 	$this->assertTrue(
@@ -19,7 +19,7 @@ it('can_set_class_extends', function() {
 });
     
 
-it('can_set_class_extends_when_its_empty', function() {
+it('can set class extends when its empty', function() {
 	$file = PHPFile::load('app/Http/Middleware/RedirectIfAuthenticated.php')->extends("My\BaseClass");
 
 	$this->assertTrue(

--- a/tests/Unit/Endpoints/PHP/ClassImplementsTest.php
+++ b/tests/Unit/Endpoints/PHP/ClassImplementsTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_retrieve_class_implements', function() {
+it('can retrieve class implements', function() {
 	$file = PHPFile::load('app/Models/User.php');
 
 	$this->assertTrue(
@@ -10,7 +10,7 @@ it('can_retrieve_class_implements', function() {
 	);
 });
 
-it('can_set_class_implements', function() {
+it('can set class implements', function() {
 	$file = PHPFile::load('app/Models/User.php')->implements([
 	"MyInterface"
 	]);
@@ -22,7 +22,7 @@ it('can_set_class_implements', function() {
 	);
 });
 
-it('can_add_class_implements', function() {
+it('can add class implements', function() {
 	$file = PHPFile::load('app/Models/User.php')
 		->add()->implements(['MyFirstInterface'])
 		->add()->implements(['MySecondInterface']);

--- a/tests/Unit/Endpoints/PHP/ClassMethodNamesTest.php
+++ b/tests/Unit/Endpoints/PHP/ClassMethodNamesTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_retrieve_class_method_names', function() {
+it('can retrieve class method names', function() {
 	$file = PHPFile::load('app/Console/Kernel.php');
 
 	$this->assertTrue(

--- a/tests/Unit/Endpoints/PHP/ClassNameTest.php
+++ b/tests/Unit/Endpoints/PHP/ClassNameTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_retrieve_class_name', function() {
+it('can retrieve class name', function() {
 	$file = PHPFile::load('app/Models/User.php');
 
 	$this->assertTrue(
@@ -10,7 +10,7 @@ it('can_retrieve_class_name', function() {
 	);
 });
     
-it('can_retrieve_full_class_name', function() {
+it('can retrieve full class name', function() {
 	$file = PHPFile::load('app/Models/User.php');
 
 	$this->assertTrue(
@@ -18,7 +18,7 @@ it('can_retrieve_full_class_name', function() {
 	);
 });
 
-it('can_set_class_name', function() {
+it('can set class name', function() {
 	// on a file with a class
 	$this->assertTrue(
 		PHPFile::load('app/Models/User.php')->className("NewName")->className() === "NewName"

--- a/tests/Unit/Endpoints/PHP/MakerTest.php
+++ b/tests/Unit/Endpoints/PHP/MakerTest.php
@@ -2,28 +2,28 @@
 
 use Archetype\Facades\PHPFile;
 
-it('it_can_make_files_with_basic_php_templates', function () {
+it('it can make files with basic php templates', function () {
 	$this->assertInstanceOf(
 		\Archetype\PHPFile::class,
 		PHPFile::make()->class('CoolClass')
 	);
 });
 
-it('the_php_file_maker_defaults_to_root', function () {
+it('the php file maker defaults to root', function () {
 	$output = PHPFile::make()->file('script.php')->outputDriver();
 	$this->assertEquals('', $output->relativeDir);
 	$this->assertEquals('script', $output->filename);
 	$this->assertEquals('php', $output->extension);
 });
 
-it('the_php_file_maker_can_write_into_directories', function () {
+it('the php file maker can write into directories', function () {
 	$output = PHPFile::make()->file('app/HTTP/script.php')->outputDriver();
 	$this->assertEquals('app/HTTP', $output->relativeDir);
 	$this->assertEquals('script', $output->filename);
 	$this->assertEquals('php', $output->extension);
 });
     
-it('the_php_class_maker_accepts_a_namespaced_class', function () {
+it('the php class maker accepts a namespaced class', function () {
 	$file = PHPFile::make()->class('Weapons\RocketLauncher');
 	
 	$output = $file->outputDriver();

--- a/tests/Unit/Endpoints/PHP/NamespaceTest.php
+++ b/tests/Unit/Endpoints/PHP/NamespaceTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_retrieve_namespace', function() {
+it('can retrieve namespace', function() {
 	// on a file with namespace
 	$this->assertTrue(
 		PHPFile::load('app/Models/User.php')->namespace() === 'App\Models'
@@ -14,7 +14,7 @@ it('can_retrieve_namespace', function() {
 	);
 });
 
-it('can_set_namespace', function() {
+it('can set namespace', function() {
 	// on a file with namespace
 	$this->assertTrue(
 		PHPFile::load('app/Models/User.php')->namespace('New\Namespace')->namespace() === 'New\Namespace'
@@ -26,7 +26,7 @@ it('can_set_namespace', function() {
 	);
 });
     
-it('can_remove_namespace', function() {
+it('can remove namespace', function() {
 	// on a file with namespace
 	$this->assertTrue(
 		PHPFile::load('app/Models/User.php')->remove()->namespace()->namespace() === null

--- a/tests/Unit/Endpoints/PHP/PHPFileQueryBuilderTest.php
+++ b/tests/Unit/Endpoints/PHP/PHPFileQueryBuilderTest.php
@@ -5,7 +5,7 @@ use Archetype\Endpoints\Laravel\LaravelFileQueryBuilder;
 use Archetype\Facades\LaravelFile;
 use Archetype\Facades\PHPFile;
 
-it('can_instanciate_via_php_or_laravel_file_with_in_method', function() {
+it('can instanciate via php or laravel file with in method', function() {
 	$this->assertInstanceOf(
 		PHPFileQueryBuilder::class,
 		PHPFile::in('app')
@@ -17,7 +17,7 @@ it('can_instanciate_via_php_or_laravel_file_with_in_method', function() {
 	);
 });
 
-it('will_return_a_collection_on_get', function() {
+it('will return a collection on get', function() {
 	$this->assertInstanceOf(
 		\Illuminate\Support\Collection::class,
 		LaravelFile::in('app')->get()
@@ -29,7 +29,7 @@ it('will_return_a_collection_on_get', function() {
 	);
 });
     
-it('can_filter_with_in_method', function() {
+it('can filter with in method', function() {
 	$this->assertCount(
 		1,
 		LaravelFile::in('public')->get()
@@ -41,7 +41,7 @@ it('can_filter_with_in_method', function() {
 	);
 });
 
-it('can_filter_with_where_method', function() {
+it('can filter with where method', function() {
 	$this->assertCount(
 		0,
 		LaravelFile::in('public')->where('className', 'User')->get()
@@ -88,7 +88,7 @@ it('can_filter_with_where_method', function() {
 	);
 });
 
-it('can_filter_with_where_method_using_an_array', function() {
+it('can filter with where method using an array', function() {
 	$this->assertCount(
 		1,
 		LaravelFile::in('app')->where([
@@ -98,7 +98,7 @@ it('can_filter_with_where_method_using_an_array', function() {
 	);
 });
 
-it('can_add_filters_with_andWhere', function() {
+it('can add filters with andWhere', function() {
 	$this->assertCount(
 		1,
 		LaravelFile::in('app')
@@ -108,7 +108,7 @@ it('can_add_filters_with_andWhere', function() {
 	);
 });
 
-it('can_filter_with_closure', function() {
+it('can filter with closure', function() {
 	$this->assertCount(
 		2,
 		LaravelFile::in('app')->where(function ($file) {
@@ -117,14 +117,14 @@ it('can_filter_with_closure', function() {
 	);
 });
     
-it('can_query_non_class_files_and_files_missing_extend', function() {
+it('can query non class files and files missing extend', function() {
 	$files = LaravelFile::where('extends', 'Authenticatable')->get();
 	$this->assertTrue(
 		$files->count() > 0
 	);
 });
     
-it('can_chain', function() {
+it('can chain', function() {
 	$files = LaravelFile::where('extends', 'ServiceProvider')
 		->where('methodNames', 'contains', 'boot')
 		->where(function ($file) {
@@ -137,7 +137,7 @@ it('can_chain', function() {
 	);
 });
     
-it('has_a_first_method', function() {
+it('has a first method', function() {
 	$this->assertInstanceOf(
 		\Archetype\LaravelFile::class,
 		LaravelFile::in('public')->first()

--- a/tests/Unit/Endpoints/PHP/PropertyTest.php
+++ b/tests/Unit/Endpoints/PHP/PropertyTest.php
@@ -1,151 +1,104 @@
 <?php
 
-use Archetype\Facades\PHPFile;
+use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;
 
-it('can_get_a_class_property', function() {
-	$property = PHPFile::load('app/Models/User.php')->property('fillable');
-
-	$this->assertTrue(
-		is_array($property)
-	);
+it('can get a class property', function() {
+	PHPFile::load('app/Models/User.php')
+		->assertProperty('fillable', ['name', 'email', 'password']);
 });
 
-it('can_update_existing_class_properties', function() {
-	$newValue = 'Reset fillable to a single string!';
-	$property = PHPFile::load('app/Models/User.php')
-		->property('fillable', $newValue)
-		->property('fillable');
-
-	$this->assertEquals(
-		$property,
-		$newValue
-	);
+it('can update existing class properties', function() {
+	PHPFile::load('app/Models/User.php')
+		->property('fillable', 'new value!')
+		->assertProperty('fillable', 'new value!');	
 });
 
-it('can_create_a_new_class_property', function() {
-	$property = PHPFile::load('app/Models/User.php')
+it('can create a new class property', function() {
+	PHPFile::load('app/Models/User.php')
 		->property('master', 'yoda')
-		->property('master');
-
-	$this->assertEquals(
-		$property,
-		'yoda'
-	);
+		->assertProperty('master', 'yoda');
 });
 	
-it('can_create_a_new_class_property_when_empty', function() {
-	$property = PHPFile::make()->class('Dummy')
+it('can create a new class property when empty', function() {
+	PHPFile::make()->class('Dummy')
 		->property('master', 'yoda')
-		->property('master');
-
-	$this->assertEquals(
-		$property,
-		'yoda'
-	);
+		->assertProperty('master', 'yoda');
 });
 	
-it('can_set_empty_property_by_using_explicit_set_method', function() {
-	$property = PHPFile::make()->class('Dummy')
+it('can set empty property by using explicit set method', function() {
+	PHPFile::make()->class('Dummy')
 		->setProperty('empty')
-		->property('empty');
-
-	$this->assertEquals(
-		$property,
-		null
-	);
+		->assertProperty('empty', null);
 });
 
-it('can_set_visibility_using_directives', function() {
-	$output = PHPFile::make()->class('Dummy')
+it('can set visibility using directives', function() {
+	PHPFile::make()->class('Dummy')
 		->private()->setProperty('parts')
-		->render();
-
-	$this->assertStringContainsString(
-		'private $parts;',
-		$output
-	);
+		->assertContains('private $parts;');
 });
 	
-it('can_remove_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can remove properties', function() {
+	PHPFile::load('app/Models/User.php')
 		->remove()->property('fillable')
-		->property('fillable');
-
-	$this->assertNull($output);
+		->assertNoProperty('fillable');
 });
 	
-it('can_clear_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can clear properties', function() {
+	PHPFile::load('app/Models/User.php')
 		->clear()->property('fillable')
-		->property('fillable');
-
-	$this->assertNull($output);
+		->assertProperty('fillable', null);
 });
 
-it('can_empty_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can empty properties', function() {
+	PHPFile::load('app/Models/User.php')
 		->empty()->property('fillable')
-		->property('fillable');
-
-		$this->assertEquals($output, []);
+		->assertProperty('fillable', []);
 });
 	
-it('can_empty_string_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can empty string properties', function() {
+	PHPFile::load('app/Models/User.php')
 		->property('someString', 'hiya')
 		->empty()->property('someString')
-		->property('someString');
-
-	$this->assertEquals($output, '');
+		->assertProperty('someString', '');
 });
 
-it('can_empty_non_array_or_string_properties_into_a_default_of_null', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can empty non array or string properties into a default of null', function() {
+	PHPFile::load('app/Models/User.php')
 		->property('someNonArrayOrStringType', 123)
 		->empty()->property('someNonArrayOrStringType')
-		->property('someNonArrayOrStringType');
-
-	$this->assertNull($output);
+		->assertProperty('someNonArrayOrStringType', null);
 });
 	
-it('can_add_to_array_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can add to array properties', function() {
+	PHPFile::load('app/Models/User.php')
 		->add()->property('fillable', 'cool')
-		->property('fillable');
-
-	$this->assertEquals(['name', 'email', 'password', 'cool'], $output);
+		->assertProperty('fillable', ['name', 'email', 'password', 'cool']);
 });
 
-it('can_add_to_string_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
+it('can add to string properties', function() {
+	PHPFile::load('app/Models/User.php')
 		->property('table', 'users')
 		->add()->property('table', '_backup')
-		->property('table');
-
-	$this->assertEquals('users_backup', $output);
+		->assertProperty('table', 'users_backup');
 });
 
-it('can_add_to_numeric_properties', function() {
-	$output = PHPFile::load('app/Models/User.php')
-		->property('allowed_errors', 1)
-		->add()->property('allowed_errors', 99)
-		->property('allowed_errors');
-
-	$this->assertEquals(100, $output);
+it('can add to numeric properties', function() {
+	PHPFile::load('app/Models/User.php')
+		->property('allowed errors', 1)
+		->add()->property('allowed errors', 99)
+		->assertProperty('allowed errors', 100);
 });
 
-it('will_default_to_add_to_an_array_if_null_or_non_value_property_is_encountered', function() {
-	$output = PHPFile::load('app/Models/User.php')
-		->setProperty('realms')
-		->add()->property('realms', 'Atlantis')
-		->property('realms');
-
-	$this->assertEquals(['Atlantis'], $output);
-
-	$output = PHPFile::load('app/Models/User.php')
+it('will default to add to an array if a null property is encountered', function() {
+	PHPFile::load('app/Models/User.php')
 		->setProperty('realms', null)
 		->add()->property('realms', 'Gondor')
-		->property('realms');
+		->assertProperty('realms', ['Gondor']);
+});
 
-	$this->assertEquals(['Gondor'], $output);
+it('will default to add to an array if a non value property is encountered', function() {
+	PHPFile::load('app/Models/User.php')
+		->setProperty('realms')
+		->add()->property('realms', 'Atlantis')
+		->assertProperty('realms', ['Atlantis']);
 });

--- a/tests/Unit/Endpoints/PHP/TraitTest.php
+++ b/tests/Unit/Endpoints/PHP/TraitTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_get_trait_names', function() {
+it('can get trait names', function() {
 	$this->assertEquals(
 		PHPFile::load('app/Models/User.php')->trait(), // Seems strange
 		['HasApiTokens', 'HasFactory', 'Notifiable']

--- a/tests/Unit/Endpoints/PHP/Use_Test.php
+++ b/tests/Unit/Endpoints/PHP/Use_Test.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_retrieve_use_statements', function () {
+it('can retrieve use statements', function () {
 	// A file with use statements
 	$file = PHPFile::load('app/Models/User.php');
 	$useStatements = $file->use();
@@ -27,7 +27,7 @@ it('can_retrieve_use_statements', function () {
 	);
 });
 
-it('can_add_use_statements_in_a_namespace', function () {
+it('can add use statements in a namespace', function () {
 	// on a file with use statements
 	$file = PHPFile::load('app/Models/User.php');
 
@@ -47,7 +47,7 @@ it('can_add_use_statements_in_a_namespace', function () {
 	});
 });
 
-it('can_add_use_statements_when_not_in_a_namespace', function () {
+it('can add use statements when not in a namespace', function () {
 	$file = PHPFile::load('public/index.php');
 	
 	$useStatements = $file->add()->use(['Add\This'])->use();
@@ -63,7 +63,7 @@ it('can_add_use_statements_when_not_in_a_namespace', function () {
 	});
 });
 
-it('can_add_use_statements_with_alias', function () {
+it('can add use statements with alias', function () {
 	$file = PHPFile::load('public/index.php');
 	$useStatements = $file->add()->use(['Add\This as Wow'])->use();
 	$expectedUseStatements = collect([
@@ -77,7 +77,7 @@ it('can_add_use_statements_with_alias', function () {
 	});
 });
 
-it('can_overwrite_use_statements', function () {
+it('can overwrite use statements', function () {
 	$file = PHPFile::load('app/Models/User.php');
 
 	$useStatements = $file->use(['Only\This'])->use();

--- a/tests/Unit/Support/AST/ASTQueryBuilderTest.php
+++ b/tests/Unit/Support/AST/ASTQueryBuilderTest.php
@@ -3,7 +3,7 @@
 use Archetype\Facades\LaravelFile;
 use Archetype\Support\AST\ASTQueryBuilder;
 
-it('can_be_instanciated_using_an_ast_object', function() {
+it('can be instanciated using an ast object', function() {
 	$ast = LaravelFile::load('app/Models/User.php')->ast();
 	
 	$ASTQB = new ASTQueryBuilder($ast);
@@ -14,7 +14,7 @@ it('can_be_instanciated_using_an_ast_object', function() {
 	);
 });
 
-it('will_return_instance_of_itself_on_chain', function() {
+it('will return instance of itself on chain', function() {
 	$ast = LaravelFile::load('app/Models/User.php')->ast();
 
 	$result = (new ASTQueryBuilder($ast))
@@ -26,7 +26,7 @@ it('will_return_instance_of_itself_on_chain', function() {
 	);
 });
 
-it('can_query_deep', function() {
+it('can query deep', function() {
 	$result = LaravelFile::load(
 		'database/migrations/2014_10_12_000000_create_users_table.php'
 	)

--- a/tests/Unit/Support/AST/PrettyPrintingTest.php
+++ b/tests/Unit/Support/AST/PrettyPrintingTest.php
@@ -30,7 +30,7 @@ class Bird
 }
 CODE;
 
-it('two_line_breaks_separate_methods', function() {
+it('two line breaks separate methods', function() {
 	$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
 	$prettyPrinter = new PSR2PrettyPrinter;
 
@@ -49,7 +49,7 @@ it('two_line_breaks_separate_methods', function() {
 	);
 });
 
-it('there_is_not_a_missing_space_between_methods_when_format_preserving_pretty_printing', function() {
+it('there is not a missing space between methods when format preserving pretty printing', function() {
 	$this->markTestIncomplete();
 	
 	$lexer = new Lexer\Emulative([

--- a/tests/Unit/Support/FloatingSnippetTest.php
+++ b/tests/Unit/Support/FloatingSnippetTest.php
@@ -3,7 +3,7 @@
 use Archetype\Support\Snippet;
 use Archetype\Support\AST\Visitors\FormattingRemover;
 
-it('can_create_a_snippet_without_position_attributes', function() {
+it('can create a snippet without position attributes', function() {
 	$fromSnippet = Snippet::___HAS_MANY_METHOD___();
 	
 	$fromSnippet = FormattingRemover::on($fromSnippet);

--- a/tests/Unit/Support/PathTest.php
+++ b/tests/Unit/Support/PathTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Support\Path;
 
-it('can_create_paths_with_explicit_default_root', function() {
+it('can create paths with explicit default root', function() {
 	$relative = Path::make('app/Models/User.php')->withDefaultRoot(base_path())->full();
 	$expected = base_path('app/Models/User.php');
 	$this->assertEquals($expected, $relative);
@@ -13,7 +13,7 @@ it('can_create_paths_with_explicit_default_root', function() {
 	$this->assertEquals($expected, $absolute);
 });
 
-it('can_create_paths_with_assumed_root', function() {
+it('can create paths with assumed root', function() {
 	$expected = '/app/Models/User.php';
 	$relative = Path::make('app/Models/User.php')->full();
 	$absolute = Path::make('/app/Models/User.php')->full();

--- a/tests/Unit/Support/SnippetTest.php
+++ b/tests/Unit/Support/SnippetTest.php
@@ -4,14 +4,14 @@ use Archetype\Facades\LaravelFile;
 use PhpParser\Node\Stmt\ClassMethod;
 use Archetype\Support\Snippet;
 
-it('can_load_class_methods_from_snippet_defaults', function() {
+it('can load class methods from snippet defaults', function() {
 	$this->assertInstanceOf(
 		ClassMethod::class,
 		Snippet::___HAS_MANY_METHOD___()
 	);
 });
 
-it('can_replace_snippet_names', function() {
+it('can replace snippet names', function() {
 	$method = Snippet::___HAS_MANY_METHOD___([
 		'___HAS_MANY_METHOD___' => 'guitars'
 	]);
@@ -27,7 +27,7 @@ it('can_replace_snippet_names', function() {
 	);
 });
 
-it('cant_load_non_existing_snippets_from_defaults', function() {
+it('cant load non existing snippets from defaults', function() {
 	$this->assertNull(
 		Snippet::NoSUchSnippet()
 	);

--- a/tests/Unit/Support/URITest.php
+++ b/tests/Unit/Support/URITest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Support\URI;
 
-it('can_enterpret_input_as_path_or_name', function() {
+it('can enterpret input as path or name', function() {
 	$this->assertTrue(URI::make('')->isPath());
 	$this->assertTrue(URI::make('car')->isPath());
 	$this->assertTrue(URI::make('car.php')->isPath());
@@ -16,7 +16,7 @@ it('can_enterpret_input_as_path_or_name', function() {
 	$this->assertTrue(URI::make('\\App\\Car')->isName());
 });
 
-it('can_get_resolve_namespace', function() {
+it('can get resolve namespace', function() {
 	$namespaces = [
 		// from paths
 		'App' => URI::make('app/Cool')->namespace(),

--- a/tests/Unit/Traits/APIDelegationTest.php
+++ b/tests/Unit/Traits/APIDelegationTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('can_delegate_method_calls', function () {
+it('can delegate method calls', function () {
 	$file = PHPFile::load('app/Models/User.php');
 
 	// Existing method on $this

--- a/tests/Unit/Traits/DirectivesTest.php
+++ b/tests/Unit/Traits/DirectivesTest.php
@@ -2,7 +2,7 @@
 
 use Archetype\Facades\PHPFile;
 
-it('will_remember_directives_when_chained', function () {
+it('will remember directives when chained', function () {
 	$file = PHPFile::load('app/Models/User.php')->add()->remove();
 
 	$this->assertEquals(
@@ -11,7 +11,7 @@ it('will_remember_directives_when_chained', function () {
 	);
 });
     
-it('will_forget_directives_on_continue', function () {
+it('will forget directives on continue', function () {
 	$file = PHPFile::load('app/Models/User.php')->add()->remove()->continue();
 	$this->assertEmpty(
 		$file->directives()


### PR DESCRIPTION
With this we can let the file instance chain the assertions it needs to do upon itself:

```php
use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;

it('can create a new class property', function() {
	PHPFile::load('app/Models/User.php')
		->property('master', 'yoda')
		->assertValidPhp()
		->assertProperty('master', 'yoda');
});
```