### PR TITLE
Remove confusing classMethod alias

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -111,7 +111,7 @@ Example: how can we fetch explicit column names in a migration file?
 LaravelFile::load('database/migrations/2014_10_12_000000_create_users_table.php')
     ->astQuery() // get a ASTQueryBuilder
 
-    ->method()
+    ->classMethod()
         ->where('name->name', 'up')
     ->staticCall()
         ->where('class', 'Schema')

--- a/src/Endpoints/PHP/MethodNames.php
+++ b/src/Endpoints/PHP/MethodNames.php
@@ -18,7 +18,7 @@ class MethodNames extends EndpointProvider
     protected function get()
     {
         return $this->file->astQuery()
-            ->method()
+            ->classMethod()
             ->name
             ->name
             ->get()

--- a/src/Traits/PHPParserClassMap.php
+++ b/src/Traits/PHPParserClassMap.php
@@ -153,9 +153,6 @@ trait PHPParserClassMap
             'unset_' => '\PhpParser\Node\Stmt\Unset_',
             'use_' => '\PhpParser\Node\Stmt\Use_',
             'while_' => '\PhpParser\Node\Stmt\While_',
-            
-            // SHORTCUTS AND CUSTOMIZATIONS
-            'method' => '\PhpParser\Node\Stmt\ClassMethod',
         ];
         
         if (!$class) {

--- a/tests/Unit/Support/AST/ASTQueryBuilderTest.php
+++ b/tests/Unit/Support/AST/ASTQueryBuilderTest.php
@@ -31,7 +31,7 @@ it('can query deep', function() {
 		'database/migrations/2014_10_12_000000_create_users_table.php'
 	)
 		->astQuery() // get a ASTQueryBuilder
-		->method()
+		->classMethod()
 			->where('name->name', 'up')
 		->staticCall()
 			->where('class', 'Schema')


### PR DESCRIPTION
This PR removes  `method` shortcut in ASTQueries in favor of the full name `classMethod`. This is because all astQueries should as a convention strictly reflect the node types.

### Before
```php
$file->astQuery()->method()
```

### Now
```php
$file->astQuery()->classMethod()
```