### PR TITLE
Put array formatting assertions on TestablePHPFile

### DIFF
--- a/tests/Feature/PrettyPrintTest.php
+++ b/tests/Feature/PrettyPrintTest.php
@@ -1,33 +1,26 @@
 <?php
 
-use Archetype\Facades\LaravelFile;
-use Archetype\Facades\PHPFile;
+use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;
 
 test('arrays are beutiful when loaded and rendered', function() {
-	$output = LaravelFile::user()->render();
-	$this->assertMultilineArray('fillable', $output);
+	PHPFile::load('app/Models/User.php')
+		->assertMultilineArray('fillable');
 });
 
 test('arrays are beutiful when loaded modified and rendered', function() {
-	$output = LaravelFile::user()
+	PHPFile::load('app/Models/User.php')
 		->add('also')->to()->property('fillable')
-		->render();
-
-	$this->assertMultilineArray('fillable', $output);
+		->assertMultilineArray('fillable');
 });
 
 test('arrays are beautiful when created and rendered', function() {
-	$output = PHPFile::class('FillableClass')
-		->add()->property('fillable', ['first', 'second', 'third'])
-		->render();
-
-	$this->assertMultilineArray('fillable', $output);
+	PHPFile::make()->class('CountClass')
+		->add()->property('counts', ['first', 'second', 'third'])
+		->assertMultilineArray('counts');
 });
 
 test('arrays are beutiful when empty', function() {
-	$output = PHPFile::class('FillableClass')
+	PHPFile::class('FillableClass')
 		->property('fillable', [])
-		->render();
-	
-	$this->assertSingleLineEmptyArray('fillable', $output);
+		->assertSingleLineEmptyArray('fillable');
 });

--- a/tests/Support/TestablePHPFile.php
+++ b/tests/Support/TestablePHPFile.php
@@ -7,6 +7,7 @@ use Archetype\PHPFile;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertFalse;
 use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertMatchesRegularExpression;
 use function PHPUnit\Framework\assertStringContainsString;
 
 class TestablePHPFile extends PHPFile
@@ -80,4 +81,23 @@ class TestablePHPFile extends PHPFile
 
 		return $this;
 	}
+
+	public function assertMultilineArray($name) {
+		preg_match("/$name \= (\[[^\;]*)/s", $this->render(), $matches);
+		$code = $matches[1];
+		$commas = substr_count($code, ',');
+		
+		assertEquals(
+			substr_count($code, PHP_EOL),
+			$commas + 1
+		);
+
+		return $this;
+	}
+
+	public function assertSingleLineEmptyArray($name) {
+		assertMatchesRegularExpression("/$name \= (\[\];]*)/s", $this->render());
+
+		return $this;		
+	}	
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -63,19 +63,4 @@ class TestCase extends \Orchestra\Testbench\TestCase
             File::deleteDirectory($directory);
         });
     }
-
-	public function assertMultilineArray($name, $output) {
-		preg_match("/$name \= (\[[^\;]*)/s", $output, $matches);
-		$code = $matches[1];
-		$commas = substr_count($code, ',');
-		
-		$this->assertEquals(
-			substr_count($code, PHP_EOL),
-			$commas + 1
-		);
-	}
-
-	public function assertSingleLineEmptyArray($name, $output) {
-		$this->assertMatchesRegularExpression("/$name \= (\[\];]*)/s", $output);
-	}	
 }


### PR DESCRIPTION
Introduce formatting assertions on `TestablePHPFile` so we can do

```php
PHPFile::load('app/Models/User.php')
    // do something, then
    ->assertMultilineArray('fillable');
    // or
    ->assertSingleLineEmptyArray('fillable');
```