### PR TITLE
HigherOrderWhere for ASTQuery and combined class/property navigation

### DIFF
--- a/src/Endpoints/PHP/AstQuery.php
+++ b/src/Endpoints/PHP/AstQuery.php
@@ -21,7 +21,7 @@ class AstQuery extends EndpointProvider
         $builder = new $builderClass($this->file->ast());
         
         // Attach the file so we can return it later
-        $builder->file = $this->file;
+        $builder->parent = $this->file;
         
         return $builder;
     }

--- a/src/Endpoints/PHP/Property.php
+++ b/src/Endpoints/PHP/Property.php
@@ -232,11 +232,7 @@ class Property extends EndpointProvider
         return $this->file->astQuery()
             ->class()
             ->property()
-            ->where(function ($query) use ($key) {
-                return $query->propertyProperty()
-                    ->where('name->name', $key)
-                    ->isNotEmpty();
-            })
+			->where->propertyProperty('name->name')->is($key)->get()
             ->replace(function ($property) {
                 $property->flags = $this->flagCode();
                 return $property;

--- a/src/Support/AST/HigherOrderWhere.php
+++ b/src/Support/AST/HigherOrderWhere.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Archetype\Support\AST;
+
+use Illuminate\Support\Arr;
+
+class HigherOrderWhere
+{
+	protected $target;
+
+	protected $subQuery;
+
+	protected $stack = [];
+
+	public function __construct($target)
+	{
+		$this->target = $target;
+	}	
+
+    public function __call(string $method, array $args = [])
+    {
+		array_push($this->stack, ['__call', $method, $args]);
+		
+		return $this;
+    }
+
+    public function __get(string $name)
+	{
+		array_push($this->stack, ['__name', $name]);	
+
+		return $this;
+	}
+
+    public function get()
+	{
+		$this->target->next(function ($queryNode) {
+			$subQuery = $this->getSubQuery($queryNode);
+			return $this->applyStack($subQuery)->isNotEmpty()
+				? $queryNode
+				: new Killable;
+		});
+
+		return $this->target;
+	}
+
+    public function isNotEmpty()
+	{
+		return $this->get();
+	}
+	
+	protected function getSubQuery($queryNode)
+	{
+		return new ASTQueryBuilder(
+			Arr::wrap((clone $queryNode)->result)
+		);
+	}
+
+	protected function applyStack($query)
+	{
+		foreach($this->stack as $item) {
+			if($item[0] == '__call') {
+				$method = $item[1];
+				$args = $item[2];
+				$query->$method(...$args);
+			} else {
+				$property = $item[1];
+				$query->$property;
+			}
+		}
+
+		return $query;
+	}
+}

--- a/tests/Unit/Facades/PHPFileTest.php
+++ b/tests/Unit/Facades/PHPFileTest.php
@@ -110,14 +110,13 @@ describe('#fromString', function() {
 });
 
 describe('#__call', function() {
+	it('catches non existing methods', function () {
+		PHPFile::this_method_does_not_exists();
+	})->throws(BadMethodCallException::class);
+
 	it('can delegate method calls to resources', function () {
 		PHPFile::make()->class()->assertInstanceOf(
 			\Archetype\Tests\Support\TestablePHPFile::class
 		);
-	});
-	
-	it('catches non existing methods', function () {
-		$this->expectException(BadMethodCallException::class);
-		PHPFile::this_method_does_not_exists();
-	});
+	});	
 });

--- a/tests/Unit/Support/AST/ASTQueryBuilderTest.php
+++ b/tests/Unit/Support/AST/ASTQueryBuilderTest.php
@@ -140,3 +140,33 @@ test('where closures returning false are considered falsy', function() {
 		->where(fn($_) => false)
 		->assertMatchCount(0);
 });
+
+test('it can use higher order queries', function() {
+	// get all array properties with string items inside
+	PHPFile::load('app/Exceptions/Handler.php')
+		->astQuery()
+		->class()
+		->property()
+		->propertyProperty()
+		->where->array()->string()->get()
+		->name->name
+		->assertMatches(collect(['dontFlash']));
+});
+
+test('whereEquals can filter on result itself', function() {
+	PHPFile::load('app/Models/User.php')
+		->astQuery()
+		->string()
+		->value
+		->assertMatchCount(7)
+		->whereEquals('email')
+		->assertMatchCount(1)
+		->assertMatches(collect(['email']));
+});
+
+it('can traverse into class properties by passing an arrow separated string', function() {
+	PHPFile::load('app/Providers/AppServiceProvider.php')
+		->astQuery()
+		->classMethod('name->name')
+		->assertMatches(collect(['register', 'boot']));
+});


### PR DESCRIPTION
* Adds ability to enter Node class and properties in one go:
```php
$astQuery->classMethod('name->name')
```

* Adds HigherOrderWhere which is a short syntax for where callbacks:
```php
$this->file->astQuery()
    ->class()
    ->property()
    ->where->propertyProperty('name->name')->is($key)->get()
    ->replace(function() {
        ...
    };

```