### PR TITLE
Allow create class by namespace

### DIFF
--- a/docs.md
+++ b/docs.md
@@ -13,7 +13,7 @@ PHPFile::make()->file('dummy.php')
 
 ### Make a class
 ```php example
-PHPFile::make()->class('Car')
+PHPFile::make()->class(\App\Models\Car::class)
 	->render()
 ```
 
@@ -22,7 +22,7 @@ PHPFile::make()->class('Car')
 ```php
 <?php
 
-namespace App;
+namespace App\Models;
 
 class Car
 {
@@ -131,7 +131,7 @@ User
 
 ### Change class name
 ```php example
-PHPFile::make()->class('Dumb')
+PHPFile::make()->class(\App\Dumb::class)
 	->className('Dumber')
 	->className()
 ```

--- a/src/Endpoints/PHP/Make.php
+++ b/src/Endpoints/PHP/Make.php
@@ -4,7 +4,9 @@ namespace Archetype\Endpoints\PHP;
 
 use Archetype\Endpoints\EndpointProvider;
 use Archetype\Support\URI;
+use Exception;
 use Illuminate\Support\Str;
+use PhpParser\BuilderFactory;
 
 class Make extends EndpointProvider
 {
@@ -20,9 +22,13 @@ class Make extends EndpointProvider
             ->outputDriver($this->outputDriver);
     }
 
-    public function class($name = 'Dummy')
+    public function class($name = \App\Dummy::class)
     {
         $this->setupNames($name, 'class_root');
+
+		if(!$this->namespace) {
+			throw new Exception('Cannot create a class without a root namespace');
+		}
 
         $contents = Str::of($this->stub('class.php.stub'))
             ->replace(['DummyNamespace', '___NAMESPACE___', '{{ namespace }}'], $this->namespace)

--- a/src/config/archetype.php
+++ b/src/config/archetype.php
@@ -56,7 +56,7 @@ return [
         
         // PHP
         'file_root' => '',
-        'class_root' => 'app',
+        'class_root' => '',
 
         // Laravel
         'commands_root' => 'app/HTTP/Controllers',

--- a/tests/Feature/Endpoints/PHP/ClassConstantTest.php
+++ b/tests/Feature/Endpoints/PHP/ClassConstantTest.php
@@ -43,7 +43,7 @@ it('can create a new class constant in an existing file', function() {
 });
 
 it('can remove an existing class constant in a new file', function() {
-	PHPFile::make()->class('Dummy')
+	PHPFile::make()->class(\App\Dummy::class)
 		->classConstant('MSG', 'hi')
 		->remove()->classConstant('MSG')
 		->assertValidPhp()		

--- a/tests/Feature/Endpoints/PHP/MakeTest.php
+++ b/tests/Feature/Endpoints/PHP/MakeTest.php
@@ -7,11 +7,9 @@ it('it can make an empty file', function () {
 		->assertValidPhp();
 });
 
-it('it can make a class file', function () {
-	PHPFile::make()->class()
-		->assertValidPhp()
-		->assertBeautifulPhp();
-});
+it('it cannot make a class file without a namespace', function () {
+	PHPFile::make()->class(\Dummy::class);
+})->throws(Exception::class);
 
 test('make file defaults to root', function () {
 	$output = PHPFile::make()->file('script.php')->outputDriver();
@@ -24,22 +22,6 @@ test('the php file maker can write into directories', function () {
 	$output = PHPFile::make()->file('app/HTTP/script.php')->outputDriver();
 	$this->assertEquals('app/HTTP', $output->relativeDir);
 	$this->assertEquals('script', $output->filename);
-	$this->assertEquals('php', $output->extension);
-});
-
-it('make class defaults to app', function () {
-	$output = PHPFile::make()->class('Scripter')->outputDriver();
-	$this->assertEquals('app', $output->relativeDir);
-	$this->assertEquals('Scripter', $output->filename);
-	$this->assertEquals('php', $output->extension);
-});
-
-it('can explicitly prepend app path when creating a class', function () {
-	$this->markTestIncomplete();
-
-	$output = PHPFile::make()->class('app/Scripter')->outputDriver();
-	$this->assertEquals('app', $output->relativeDir);
-	$this->assertEquals('Scripter', $output->filename);
 	$this->assertEquals('php', $output->extension);
 });
 
@@ -57,10 +39,7 @@ it('the php class maker accepts a namespaced class', function () {
 	
 	$output = $file->outputDriver();
 
-	$this->assertEquals('app/Weapons', $output->relativeDir);
+	$this->assertEquals('Weapons', $output->relativeDir);
 	$this->assertEquals('RocketLauncher', $output->filename);
 	$this->assertEquals('php', $output->extension);
-
-	$this->assertEquals('App\Weapons', $file->namespace());
-	$this->assertEquals('RocketLauncher', $file->className());
 });

--- a/tests/Feature/Endpoints/PHP/PropertyTest.php
+++ b/tests/Feature/Endpoints/PHP/PropertyTest.php
@@ -24,7 +24,7 @@ it('can create a new class property', function() {
 });
 	
 it('can create a new class property when empty', function() {
-	PHPFile::make()->class('Dummy')
+	PHPFile::make()->class(\App\Dummy::class)
 		->property('master', 'yoda')
 		->assertProperty('master', 'yoda')
 		->assertValidPhp()
@@ -32,7 +32,7 @@ it('can create a new class property when empty', function() {
 });
 	
 it('can set empty property by using explicit set method', function() {
-	PHPFile::make()->class('Dummy')
+	PHPFile::make()->class(\App\Dummy::class)
 		->setProperty('empty')
 		->assertProperty('empty', null)
 		->assertValidPhp()
@@ -40,7 +40,7 @@ it('can set empty property by using explicit set method', function() {
 });
 
 it('can set visibility using directives', function() {
-	PHPFile::make()->class('Dummy')
+	PHPFile::make()->class(\App\Dummy::class)
 		->private()->setProperty('parts')
 		->assertContains('private $parts;')
 		->assertValidPhp()

--- a/tests/Feature/PrettyPrintTest.php
+++ b/tests/Feature/PrettyPrintTest.php
@@ -14,13 +14,13 @@ test('arrays are beutiful when loaded modified and rendered', function() {
 });
 
 test('arrays are beautiful when created and rendered', function() {
-	PHPFile::make()->class('CountClass')
+	PHPFile::make()->class()
 		->add()->property('counts', ['first', 'second', 'third'])
 		->assertMultilineArray('counts');
 });
 
 test('class statements have linebreaks between them', function() {
-	PHPFile::make()->class('CountClass')
+	PHPFile::make()->class()
 		->property('a', 1)
 		->property('b', 2)
 		->property('c', 3)

--- a/tests/Support/TestableMarkdownTest.php
+++ b/tests/Support/TestableMarkdownTest.php
@@ -26,7 +26,7 @@ MARKDOWN;
 const MAKE_AN_EMPTY_FILE = <<< 'MARKDOWN'
 ### Make an empty file
 ```php example
-PHPFile::make()->file('dummy.php')
+PHPFile::make()->file(\\App\\Dummy::class)
 	->render()
 ```
 


### PR DESCRIPTION
Now we can create classes like so:

```php
namespace App;

PHPFile::make()->class(Models\Car::class);
PHPFile::make()->class(\App\Models\Car::class);
PHPFile::make()->class('App\Models\Car');
PHPFile::make()->class('\App\Models\Car');
PHPFile::make()->class('app/Models/Car.php');
```

all of these will write two `app/Models/Car.php`.