### PR TITLE
Remove unimplemented make methods

### DIFF
--- a/src/LaravelFile.php
+++ b/src/LaravelFile.php
@@ -88,30 +88,6 @@ class LaravelFile extends PHPFile
 		$handler = new ModelProperties($this);
 		return $handler->hidden(...$args);
 	}
-	
-    public function model($name)
-    {
-		$handler = new LaravelMake($this);
-		$handler->model($name);
-    }
-
-    public function controller($name)
-    {
-		$handler = new LaravelMake($this);
-		$handler->controller($name);
-    }
-
-    public function migration($name)
-    {
-		$handler = new LaravelMake($this);
-		$handler->migration($name);
-    }
-    
-    public function factory($name)
-    {
-		$handler = new LaravelMake($this);
-		$handler->factory($name);
-    }
 
 	public function belongsTo($targets)
 	{


### PR DESCRIPTION
`LaravelFile` still had remnants of the maker. We will drop these until properly implemented.