### PR TITLE
Introduce DI for Maker

### DIFF
--- a/src/Endpoints/Maker.php
+++ b/src/Endpoints/Maker.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Archetype\Endpoints;
+
+use Archetype\PHPFile;
+
+abstract class Maker extends EndpointProvider
+{
+	public function withFile(PHPFile $file)
+	{
+		$this->file = $file;
+
+		return $this;
+	}
+}

--- a/src/Endpoints/PHP/Make.php
+++ b/src/Endpoints/PHP/Make.php
@@ -3,12 +3,13 @@
 namespace Archetype\Endpoints\PHP;
 
 use Archetype\Endpoints\EndpointProvider;
+use Archetype\Endpoints\Maker;
 use Archetype\Support\URI;
 use Exception;
 use Illuminate\Support\Str;
 use PhpParser\BuilderFactory;
 
-class Make extends EndpointProvider
+class Make extends Maker
 {
     protected string $filename;
     protected string $extension = '.php';

--- a/src/Factories/PHPFileFactory.php
+++ b/src/Factories/PHPFileFactory.php
@@ -2,6 +2,7 @@
 
 namespace Archetype\Factories;
 
+use Archetype\Endpoints\PHP\Make;
 use Archetype\PHPFile;
 
 class PHPFileFactory
@@ -21,9 +22,11 @@ class PHPFileFactory
     protected static function __makeFileInstance()
     {
         $class = static::FILE_TYPE;
-        $instance = new $class;
+        $instance = new $class(
+			new Make()
+		);
+		
         $instance->inputDriver(static::__driver('input'));
-
         $instance->outputDriver(static::__driver('output'));
 
         return $instance;

--- a/src/PHPFile.php
+++ b/src/PHPFile.php
@@ -48,9 +48,7 @@ class PHPFile
 
     protected $directives = [];
 
-    public function __construct(
-		Maker $maker,
-    ) {
+    public function __construct(Maker $maker) {
 		$this->maker = $maker;
     }	
 

--- a/src/PHPFile.php
+++ b/src/PHPFile.php
@@ -8,6 +8,7 @@ use Archetype\Endpoints\PHP\ClassName;
 use Archetype\Endpoints\PHP\Extends_;
 use Archetype\Endpoints\PHP\Implements_;
 use Archetype\Endpoints\PHP\Make;
+use Archetype\Endpoints\Maker;
 use Archetype\Endpoints\PHP\MethodNames;
 use Archetype\Endpoints\PHP\Namespace_;
 use Archetype\Endpoints\PHP\Property;
@@ -27,15 +28,11 @@ class PHPFile
     use HasDirectiveHandlers;
 	use HasSyntacticSweeteners;
 
-    protected $input;
-
-    protected $output;
-
     protected string $contents;
 
     protected string $fileQueryBuilder = Endpoints\PHP\PHPFileQueryBuilder::class;
 
-	protected string $maker = Endpoints\PHP\Make::class;
+	protected Maker $maker;
 
 	public string $astQueryBuilder = ASTQueryBuilder::class;
 
@@ -50,6 +47,12 @@ class PHPFile
     protected $lexer;
 
     protected $directives = [];
+
+    public function __construct(
+		Maker $maker,
+    ) {
+		$this->maker = $maker;
+    }	
 
 	public function query()
 	{
@@ -85,16 +88,8 @@ class PHPFile
 
 	public function make()
 	{
-		return new $this->maker($this);
+		return $this->maker->withFile($this);
 	}
-
-    public function __construct(
-        string $input = \Archetype\Drivers\FileInput::class,
-        string $output = \Archetype\Drivers\FileOutput::class
-    ) {
-        $this->input = $input;
-        $this->output = $output;
-    }
 
 	public function property($key, $value = Types::NO_VALUE)
 	{


### PR DESCRIPTION
* Drops unused input/output class parameters.
* Adds an abstract Make and $maker parameter.
* Creates a maker in the PHPFile factory
* Currently the maker needs a file instance to resolve which type to use when parsing templates, hence the withFile method. That needs improvement.