### PR TITLE
Strict object hash comparison resolves flakiness

### DIFF
--- a/src/Support/AST/Visitors/NodeInserter.php
+++ b/src/Support/AST/Visitors/NodeInserter.php
@@ -19,7 +19,7 @@ class NodeInserter extends NodeVisitorAbstract
 
     public function leaveNode(Node $node)
     {
-        return $node->__object_hash == $this->id ? [$this->newNode, $node] : $node;
+        return $node->__object_hash === $this->id ? [$this->newNode, $node] : $node;
     }
 
     public function afterTraverse(array $nodes)

--- a/src/Support/AST/Visitors/NodePropertyReplacer.php
+++ b/src/Support/AST/Visitors/NodePropertyReplacer.php
@@ -21,7 +21,7 @@ class NodePropertyReplacer extends NodeVisitorAbstract
 
     public function leaveNode(Node $node)
     {
-        if ($node->__object_hash == $this->id) {
+        if ($node->__object_hash === $this->id) {
             $node->{$this->key} = $this->value;
         }
 

--- a/src/Support/AST/Visitors/NodeRemover.php
+++ b/src/Support/AST/Visitors/NodeRemover.php
@@ -17,7 +17,7 @@ class NodeRemover extends NodeVisitorAbstract
 
     public function leaveNode(Node $node)
     {
-        return $node->__object_hash == $this->id ? NodeTraverser::REMOVE_NODE : $node;
+        return $node->__object_hash === $this->id ? NodeTraverser::REMOVE_NODE : $node;
     }
     
     public static function remove($id, $ast)

--- a/src/Support/AST/Visitors/NodeReplacer.php
+++ b/src/Support/AST/Visitors/NodeReplacer.php
@@ -19,7 +19,7 @@ class NodeReplacer extends NodeVisitorAbstract
 
     public function leaveNode(Node $node)
     {
-        return $node->__object_hash == $this->id ? $this->newNode : $node;
+        return $node->__object_hash === $this->id ? $this->newNode : $node;
     }
     
     public static function replace($id, $newNode, $ast)

--- a/src/Support/AST/Visitors/StmtInserter.php
+++ b/src/Support/AST/Visitors/StmtInserter.php
@@ -67,7 +67,7 @@ class StmtInserter extends NodeVisitorAbstract
 
     protected function isTarget($node)
     {
-        return isset($node->__object_hash) &&  $node->__object_hash == $this->id;
+        return isset($node->__object_hash) && $node->__object_hash === $this->id;
     }
 
     protected function priority($node)


### PR DESCRIPTION
Node insertion and editing was made with non strict comparison which sometimes lead to test failures. Consider:
```php
"0000000000000e480000000000000000" == "0000000000000e510000000000000000"; // true (!!!!)
"0000000000000e480000000000000000" === "0000000000000e510000000000000000"; // false
```

Now, using `===` we should be green always ✅ 