### PR TITLE
Allow passing a closure to insertStmt

### DIFF
--- a/src/Support/AST/ASTQueryBuilder.php
+++ b/src/Support/AST/ASTQueryBuilder.php
@@ -20,6 +20,7 @@ use Closure;
 use Exception;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use PhpParser\BuilderFactory;
 use PhpParser\ConstExprEvaluator;
 
 class ASTQueryBuilder
@@ -351,6 +352,8 @@ class ASTQueryBuilder
 
     public function insertStmt($newNode): self
     {
+		if($newNode instanceof Closure) $newNode = $newNode(new BuilderFactory);
+
         $this->currentNodes()->each(function ($node) use ($newNode) {
             $target = $node->result;
 

--- a/tests/Unit/Support/AST/ASTQueryBuilderTest.php
+++ b/tests/Unit/Support/AST/ASTQueryBuilderTest.php
@@ -204,3 +204,15 @@ it('does not insert statements when no matches', function() {
 	
 	assertEquals($original, $after);
 });
+
+it('can insert stmt with a closure', function() {
+	PHPFile::make()->class(\App\Dummy::class)
+		->astQuery()
+		->class()
+		->insertStmt(function(BuilderFactory $builder) {
+			return $builder->property('someProperty')->getNode();
+		})
+		->commit()
+		->end()
+		->preview();
+});


### PR DESCRIPTION
This feature provides a BuilderFactory instance when passing a closure to insertStmt.

```php
PHPFile::make()->class(\App\Dummy::class)
  ->astQuery()
  ->class()
  ->insertStmt(function(BuilderFactory $builder) {
	  return $builder->property('someProperty')->getNode();
  })
  ->commit()
  ->end()
  ->preview();
```