### PR TITLE
Basic useTrait()

### DIFF
--- a/src/Endpoints/PHP/UseTrait.php
+++ b/src/Endpoints/PHP/UseTrait.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Archetype\Endpoints\PHP;
+
+use Archetype\Endpoints\EndpointProvider;
+use PhpParser\BuilderFactory;
+use Illuminate\Support\Arr;
+
+class UseTrait extends EndpointProvider
+{
+	/**
+	 * @example Get which traits a class uses
+	 * @source $file->useTrait()
+	 */
+	public function useTrait($value = null)
+	{
+		if ($this->file->directive('add')) {
+			return $this->add($value);
+		}
+
+		if ($value === null) {
+			return $this->get();
+		}
+
+		return $this->set($value);
+	}
+
+	protected function get()
+	{
+		$r = $this->file->astQuery()
+			->class()
+			->traitUse()
+			->name()
+			->parts
+			->get()
+			->toArray();
+
+		return $r;
+	}
+
+	protected function add($newUseTraitNames)
+	{
+		return $this->file->astQuery()
+			->class()
+			->insertStmts(
+				collect(Arr::wrap($newUseTraitNames))
+					->reverse()
+					->map(function ($name) {
+						return $this->getUseTraitNode($name);
+					})->toArray()
+			)
+			->commit()
+			->end()
+			->continue();
+	}
+
+	protected function getUseTraitNode($name)
+	{
+		$factory = new BuilderFactory;
+		return $factory->useTrait($name)->getNode();
+	}
+
+	protected function set($newUseTraitNames)
+	{
+		$this->file->astQuery()
+			->traitUse()
+			->remove()
+			->commit();
+
+		$this->add($newUseTraitNames);
+
+		return $this->file;
+	}
+}

--- a/src/PHPFile.php
+++ b/src/PHPFile.php
@@ -15,6 +15,7 @@ use Archetype\Endpoints\PHP\Namespace_;
 use Archetype\Endpoints\PHP\Property;
 use Archetype\Endpoints\PHP\ReflectionProxy;
 use Archetype\Endpoints\PHP\Use_;
+use Archetype\Endpoints\PHP\UseTrait;
 use Archetype\Support\AST\ASTQueryBuilder;
 use Archetype\Support\Types;
 use Archetype\Traits\HasDirectives;
@@ -24,36 +25,36 @@ use Archetype\Traits\HasSyntacticSweeteners;
 
 class PHPFile
 {
-    use HasIO;
-    use HasDirectives;
-    use HasDirectiveHandlers;
+	use HasIO;
+	use HasDirectives;
+	use HasDirectiveHandlers;
 	use HasSyntacticSweeteners;
 
 	public InputInterface $input;
 
 	public OutputInterface $output;
 
-    protected string $contents;
+	protected string $contents;
 
-    protected string $fileQueryBuilder = Endpoints\PHP\PHPFileQueryBuilder::class;
+	protected string $fileQueryBuilder = Endpoints\PHP\PHPFileQueryBuilder::class;
 
 	protected Maker $maker;
 
 	public string $astQueryBuilder = ASTQueryBuilder::class;
 
-    protected $ast;
+	protected $ast;
 
-    protected string $initialModificationHash;
+	protected string $initialModificationHash;
 
-    protected $originalAst;
+	protected $originalAst;
 
-    protected $tokens;
+	protected $tokens;
 
-    protected $lexer;
+	protected $lexer;
 
-    protected $directives = [];
+	protected $directives = [];
 
-    public function __construct(
+	public function __construct(
 		InputInterface $input,
 		OutputInterface $output,
 		Maker $maker
@@ -61,7 +62,7 @@ class PHPFile
 		$this->input = $input;
 		$this->output = $output;
 		$this->maker = $maker;
-    }	
+	}
 
 	public function query()
 	{
@@ -77,11 +78,11 @@ class PHPFile
 	{
 		return $this->query()->in(...$args);
 	}
-	
+
 	public function where(...$args)
 	{
 		return $this->query()->where(...$args);
-	}	
+	}
 
 	public function astQuery()
 	{
@@ -106,16 +107,22 @@ class PHPFile
 		return $handler->property($key, $value);
 	}
 
-    public function setProperty($key, $value = Types::NO_VALUE)
-    {
+	public function setProperty($key, $value = Types::NO_VALUE)
+	{
 		$handler = new Property($this);
-		return $handler->setProperty($key, $value);		
-    }
-	
+		return $handler->setProperty($key, $value);
+	}
+
 	public function use($value = null)
 	{
 		$handler = new Use_($this);
 		return $handler->use($value);
+	}
+
+	public function useTrait($value = null)
+	{
+		$handler = new UseTrait($this);
+		return $handler->useTrait($value);
 	}
 
 	public function namespace(string $value = null)
@@ -129,7 +136,7 @@ class PHPFile
 		$handler = new MethodNames($this);
 		return $handler->methodNames();
 	}
-	
+
 	public function implements($name = null)
 	{
 		$handler = new Implements_($this);
@@ -141,13 +148,13 @@ class PHPFile
 		$handler = new Extends_($this);
 		return $handler->extends($name);
 	}
-	
+
 	public function className($name = null)
 	{
 		$handler = new ClassName($this);
 		return $handler->className($name);
 	}
-	
+
 	public function classConstant($key, $value = Types::NO_VALUE)
 	{
 		$handler = new ClassConstant($this);
@@ -158,5 +165,5 @@ class PHPFile
 	{
 		$handler = new ClassConstant($this);
 		return $handler->setClassConstant($key, $value);
-	}	
+	}
 }

--- a/tests/Feature/Endpoints/PHP/UseTraitTest.php
+++ b/tests/Feature/Endpoints/PHP/UseTraitTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Archetype\Tests\Support\Facades\TestablePHPFile as PHPFile;
+
+it('can retrieve class trait use statements', function () {
+	PHPFile::load('app/Models/User.php')
+		->assertUseTrait([
+			'HasApiTokens',
+			'HasFactory',
+			'Notifiable',
+		]);
+});
+
+it('can retrieve class trait use statements with mixed grouping', function () {
+	PHPFile::fromString('class X { use A, B; use C; }')
+		->assertUseTrait(['A', 'B', 'C']);
+});
+
+it('overwrites existing statements when setting a single value', function () {
+	PHPFile::fromString('class X { use A, B; use C; }')
+		->useTrait('NewTrait')
+		->assertUseTrait(['NewTrait']); //->assertBeautifulPhp();
+});
+
+it('overwrites existing statements when setting many values', function () {
+	PHPFile::fromString('class X { use A, B; use C; }')
+		->useTrait(['D', 'E'])
+		->assertUseTrait(['D', 'E']); //->assertBeautifulPhp();
+});
+
+it('can add class use trait statements by unshifting (!)', function () {
+	PHPFile::fromString('class X { use A; }')
+		->add()->useTrait('B')
+		->assertUseTrait(['B', 'A']); //->assertBeautifulPhp();
+});

--- a/tests/Feature/Endpoints/PHP/UseTraitTest.php
+++ b/tests/Feature/Endpoints/PHP/UseTraitTest.php
@@ -33,3 +33,9 @@ it('can add class use trait statements by unshifting (!)', function () {
 		->add()->useTrait('B')
 		->assertUseTrait(['B', 'A']); //->assertBeautifulPhp();
 });
+
+it('can add multiple class use trait statements', function () {
+	PHPFile::fromString('class X { use A; }')
+		->add()->useTrait(['B', 'C'])
+		->assertUseTrait(['B', 'C', 'A']); //->assertBeautifulPhp();
+});

--- a/tests/Support/TestablePHPFile.php
+++ b/tests/Support/TestablePHPFile.php
@@ -25,7 +25,7 @@ class TestablePHPFile extends PHPFile
 
 	public function assertDirectives($expectedMap)
 	{
-		foreach($expectedMap as $name => $expected) {
+		foreach ($expectedMap as $name => $expected) {
 			$this->assertDirective($name, $expected);
 		}
 
@@ -45,7 +45,7 @@ class TestablePHPFile extends PHPFile
 
 		return $this;
 	}
-	
+
 	public function assertInstanceOfTestablePHPile()
 	{
 		return $this->assertInstanceOf(\Archetype\Tests\Support\TestablePHPFile::class);
@@ -82,13 +82,13 @@ class TestablePHPFile extends PHPFile
 	public function assertNoClassConstant(string $name)
 	{
 		$exists = $this->astQuery()
-            ->class()
-            ->classConst()
-            ->where(function ($query) use ($name) {
-                return $query->const()
+			->class()
+			->classConst()
+			->where(function ($query) use ($name) {
+				return $query->const()
 					->where('name->name', $name)
 					->isNotEmpty();
-            })->get()
+			})->get()
 			->isNotEmpty();
 
 		assertFalse($exists);
@@ -106,13 +106,13 @@ class TestablePHPFile extends PHPFile
 	public function assertNoProperty(string $name)
 	{
 		$exists = $this->astQuery()
-            ->class()
-            ->property()
-            ->where(function ($query) use ($name) {
-                return $query->propertyProperty()
+			->class()
+			->property()
+			->where(function ($query) use ($name) {
+				return $query->propertyProperty()
 					->where('name->name', $name)
 					->isNotEmpty();
-            })->get()
+			})->get()
 			->isNotEmpty();
 
 		assertFalse($exists);
@@ -123,7 +123,7 @@ class TestablePHPFile extends PHPFile
 	public function assertProperty($name, $value)
 	{
 		assertEquals($this->property($name), $value);
-		
+
 		return $this;
 	}
 
@@ -142,7 +142,14 @@ class TestablePHPFile extends PHPFile
 		assertEquals($expected, $this->use());
 
 		return $this;
-	}	
+	}
+
+	public function assertUseTrait(array $expected = null)
+	{
+		assertEquals($expected, $this->useTrait());
+
+		return $this;
+	}
 
 	public function assertValidPhp()
 	{
@@ -160,13 +167,14 @@ class TestablePHPFile extends PHPFile
 		$this->assertLinebreaksBetweenClassStmts();
 
 		return $this;
-	}	
+	}
 
-	public function assertMultilineArray($name) {
+	public function assertMultilineArray($name)
+	{
 		preg_match("/$name \= (\[[^\;]*)/s", $this->render(), $matches);
 		$code = $matches[1];
 		$commas = substr_count($code, ',');
-		
+
 		assertEquals(
 			substr_count($code, PHP_EOL),
 			$commas + 1
@@ -182,21 +190,22 @@ class TestablePHPFile extends PHPFile
 		return $this;
 	}
 
-	public function assertSingleLineEmptyArray($name) {
+	public function assertSingleLineEmptyArray($name)
+	{
 		assertMatchesRegularExpression("/$name \= (\[\];]*)/s", $this->render());
 
-		return $this;		
+		return $this;
 	}
 
 	public function assertProperSpacingInClassHeader()
 	{
-		if(!$this->hasClass()) return $this;
+		if (!$this->hasClass()) return $this;
 
 		$this->assertOneEmptyLineBetweenPhpTagAndNamespace();
 
 		return $this->hasUseStatements()
 			? $this->assertOneEmptyLineBetweenNamespaceAndUseStatements()
-				->assertOneEmptyLineBetweenUseStatementsAndClass()
+			->assertOneEmptyLineBetweenUseStatementsAndClass()
 			: $this->assertOneEmptyLineBetweenNamespaceAndClass();
 	}
 
@@ -226,20 +235,21 @@ class TestablePHPFile extends PHPFile
 		assertMatchesRegularExpression('/namespace .*\n\nuse /', $this->render());
 
 		return $this;
-	}	
+	}
 
-	public function assertLinebreaksBetweenClassStmts() {
+	public function assertLinebreaksBetweenClassStmts()
+	{
 		// Reparse to resolve formatting 
 		$this->fromString($this->render());
 
 		$class = $this->astQuery()->class()->first();
-		if(!$class) return $this;
+		if (!$class) return $this;
 
 		$stmts = $this->astQuery()->class()->stmts->get();
 
 		$lineNumberCursor = $class->getStartLine() + 2;
-		
-		$stmts->each(function($stmt, $index) use(&$lineNumberCursor) {
+
+		$stmts->each(function ($stmt, $index) use (&$lineNumberCursor) {
 			$startLine = collect([
 				$stmt->getStartLine(),
 				collect($stmt->getComments())->map->getStartLine()->min()
@@ -249,7 +259,7 @@ class TestablePHPFile extends PHPFile
 				$lineNumberCursor,
 				$startLine,
 				'Missing linebreaks between class statements:'
-					.PHP_EOL.PHP_EOL.$this->render()
+					. PHP_EOL . PHP_EOL . $this->render()
 			);
 
 			$lineNumberCursor = $stmt->getEndLine() + 2;
@@ -266,5 +276,5 @@ class TestablePHPFile extends PHPFile
 	protected function hasUsestatements(): bool
 	{
 		return preg_match('/^use /m', $this->render());
-	}	
+	}
 }


### PR DESCRIPTION
This PR adds basic operations for trait usage in a class.
```php
class X {
    use TraitA;
}
```
It is to be considered an experimental iteration 1 and might be subject to change without a semver major bump. @ this PR if you want a notification for upcoming changes.

### Retrieve used traits
```php
$file->useTrait()
```
It will retrieve all traits as strings, grouped or not grouped alike.

### Set used traits
```php
$file->useTrait('TraitA')
$file->useTrait(['TraitA'])
```
The above statements are equivalent. While suggested that an array could yield a grouped statement it is not consistent with how other array input works in the package.
Note that setting useTraits will overwrite any existing traits. It will output one row per trait - no grouping.

### Add used traits
```php
$file->add()->useTrait('TraitA')
```
This will *prepend* TraitA, at the top of the class statements. It is a bit unintuitive, but thats the way the astQueryBuilder currently insterts statements (unshifting).
You may also add many at once by passing an array.

### Potential follow ups
* Fix AstQueryBuilder ->insertStmts/insertStmt - maybe do something like prepedStatement / pushStatement ?
* Add support for ->remove('SomeTrait')
* Add ability to style output in some way according to group/not group style preferences
* When the feature is stable, add documentation