### PR TITLE
Support for php-parser 5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Install Composer (macOS)
+        if: startsWith(runner.os, 'macOS')
+        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
       - name: Determine composer cache directory
         id: determine-composer-cache-directory
         run: 'echo "::set-output name=directory::$(composer config cache-dir)"'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,9 +44,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Install Composer (macOS)
-        if: startsWith(runner.os, 'macOS')
-        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
+          coverage: none
+          ini-values: "memory_limit=-1"
+          tools: composer
 
       - name: Determine composer cache directory
         id: determine-composer-cache-directory
@@ -58,14 +63,6 @@ jobs:
           path: ${{ steps.determine-composer-cache-directory.outputs.directory }}
           key: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: dependencies-os-${{ matrix.os }}-php-${{ matrix.php-version }}-laravel-${{ matrix.laravel-version }}-composer-
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php-version }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, gd
-          coverage: none
-          ini-values: "memory_limit=-1"
 
       - name: Setup problem matchers for PHP
         run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "nikic/php-parser": "^4.11"
+        "nikic/php-parser": "^5.0"
     },
     "require-dev": {
         "laravel/laravel": "^6.0 || ^7.0 || ^8.0 || ^9.0",

--- a/src/Endpoints/PHP/Extends_.php
+++ b/src/Endpoints/PHP/Extends_.php
@@ -30,10 +30,7 @@ class Extends_ extends EndpointProvider
         return $this->file->astQuery()
             ->class()
             ->extends
-            ->remember('formatted_extends', function ($node) {
-                $parts = $node->parts ?? null;
-                return $parts ? join('\\', $parts) : null;
-            })
+            ->remember('formatted_extends', fn ($node) => $node->name)
             ->recall('formatted_extends')
             ->first();
     }

--- a/src/Endpoints/PHP/Implements_.php
+++ b/src/Endpoints/PHP/Implements_.php
@@ -37,9 +37,7 @@ class Implements_ extends EndpointProvider
             ->class()
             ->implements
             ->get()
-            ->map(function ($name) {
-                return implode('\\', $name->parts);
-            })->toArray();
+            ->map(fn ($node) => $node->name)->toArray();
     }
 
     protected function set($newImplements)

--- a/src/Endpoints/PHP/Namespace_.php
+++ b/src/Endpoints/PHP/Namespace_.php
@@ -37,10 +37,7 @@ class Namespace_ extends EndpointProvider
     {
         return $this->file->astQuery()
             ->namespace()
-            ->remember('formatted_namespace', function ($node) {
-                $parts = $node->name->parts ?? null;
-                return $parts ? join('\\', $parts) : null;
-            })
+            ->remember('formatted_namespace', fn ($node) => $node->name)
             ->recall('formatted_namespace')
             ->first();
     }
@@ -53,7 +50,7 @@ class Namespace_ extends EndpointProvider
         
         if ($namespace) {
             // Modifying existing namespace
-            $namespace->name->parts = explode("\\", $newNamespace);
+            $namespace->name->name = $newNamespace;
         } else {
             // Add a namespace
             $ast = $this->file->ast();

--- a/src/Endpoints/PHP/UseTrait.php
+++ b/src/Endpoints/PHP/UseTrait.php
@@ -31,7 +31,6 @@ class UseTrait extends EndpointProvider
 			->class()
 			->traitUse()
 			->name()
-			->parts
 			->get()
 			->toArray();
 

--- a/src/Endpoints/PHP/Use_.php
+++ b/src/Endpoints/PHP/Use_.php
@@ -44,7 +44,7 @@ class Use_ extends EndpointProvider
             ->uses
             ->get()
             ->map(function ($useStatement) {
-                $base = join('\\', $useStatement->name->parts);
+                $base = $useStatement->name;
                 return $base . ($useStatement->alias ? ' as ' . $useStatement->alias : '');
             })->toArray();
     }

--- a/src/PHPFile.php
+++ b/src/PHPFile.php
@@ -50,8 +50,6 @@ class PHPFile
 
 	protected $tokens;
 
-	protected $lexer;
-
 	protected $directives = [];
 
 	public function __construct(

--- a/src/Support/AST/ShallowNodeFinder.php
+++ b/src/Support/AST/ShallowNodeFinder.php
@@ -2,6 +2,7 @@
 
 namespace Archetype\Support\AST;
 
+use PhpParser\Node;
 use PhpParser\NodeFinder;
 
 class ShallowNodeFinder extends NodeFinder
@@ -27,7 +28,7 @@ class ShallowNodeFinder extends NodeFinder
         })->filter()->flatten()->toArray();
     }
 
-    public function findFirstInstanceOf($node, string $class)
+    public function findFirstInstanceOf($node, string $class): ?Node
     {
         return collect($this->findInstanceOf($node, $class))->first();
     }

--- a/src/Support/PSR2PrettyPrinter.php
+++ b/src/Support/PSR2PrettyPrinter.php
@@ -18,13 +18,13 @@ class PSR2PrettyPrinter extends StandardPrettyPrinter
     }
 
     // Fix empty line before class definition
-    protected function pStmt_Class(Class_ $node)
+    protected function pStmt_Class(Class_ $node): string
     {
         return $this->pClassCommon($node, ' ' . $node->name);
     }
 
     // Fix empty line before class definition
-    protected function pStmt_ClassMethod(ClassMethod $node)
+    protected function pStmt_ClassMethod(ClassMethod $node): string
     {
         return $this->pAttrGroups($node->attrGroups)
              . $this->pModifiers($node->flags)
@@ -36,7 +36,7 @@ class PSR2PrettyPrinter extends StandardPrettyPrinter
                 : ';');
     }
 
-    protected function pExpr_Array(Array_ $node)
+    protected function pExpr_Array(Array_ $node): string
     {
 		$stmts = $this->pCommaSeparatedMultiline($node->items, true);
 		$lineBreaked = $stmts ? $stmts . $this->nl : $stmts;
@@ -48,7 +48,7 @@ class PSR2PrettyPrinter extends StandardPrettyPrinter
      *
      * @param [type] $nodes
      */
-    protected function pClassCommon(Class_ $node, $afterClassToken)
+    protected function pClassCommon(Class_ $node, $afterClassToken): string
     {
         return $this->pModifiers($node->flags)
 			. 'class' . $afterClassToken

--- a/src/Traits/HasIO.php
+++ b/src/Traits/HasIO.php
@@ -7,6 +7,7 @@ use Archetype\Support\PSR2PrettyPrinter;
 use PhpParser\Error as PHPParserError;
 use PhpParser\NodeTraverser;
 use PhpParser\NodeVisitor\CloningVisitor;
+use PhpParser\ParserFactory;
 
 trait HasIO
 {
@@ -88,23 +89,13 @@ trait HasIO
 
     public function parse()
     {
-        $this->lexer = new \PhpParser\Lexer\Emulative([
-            'usedAttributes' => [
-                'comments',
-                'startLine', 'endLine',
-                'startTokenPos', 'endTokenPos',
-            ],
-        ]);
+        $parser = (new ParserFactory)->createForNewestSupportedVersion();
 
-        $parser = new \PhpParser\Parser\Php7($this->lexer);
+        $traverser = new NodeTraverser(new CloningVisitor());
 
-        //$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        $traverser = new NodeTraverser();
-        $traverser->addVisitor(new CloningVisitor());
-        
         try {
             $this->originalAst = $parser->parse($this->contents());
-            $this->tokens = $this->lexer->getTokens();
+            $this->tokens = $parser->getTokens();
         } catch (PHPParserError $error) {
             // rethrow with extra information
             throw new FileParseError($this->input->absolutePath(), $error);

--- a/tests/Unit/Support/AST/ASTQueryBuilderTest.php
+++ b/tests/Unit/Support/AST/ASTQueryBuilderTest.php
@@ -99,7 +99,7 @@ test('resolved where closures with matches are considered truthy', function() {
 	PHPFile::fromString('class Cool extends Ice {}')
 		->astQuery()
 		->class()
-		->where(fn($query) => $query->where('extends->parts', ['Ice'])->get())
+		->where(fn($query) => $query->where('extends->name', 'Ice')->get())
 		->assertMatchCount(1);
 });
 
@@ -107,7 +107,7 @@ test('unresolved where closures with matches are considered truthy', function() 
 	PHPFile::fromString('class Cool extends Ice {}')
 		->astQuery()
 		->class()
-		->where(fn($query) => $query->where('extends->parts', ['Ice']))
+		->where(fn($query) => $query->where('extends->name', 'Ice'))
 		->assertMatchCount(1);
 });
 

--- a/tests/Unit/Support/AST/PrettyPrintingTest.php
+++ b/tests/Unit/Support/AST/PrettyPrintingTest.php
@@ -26,7 +26,7 @@ class Bird
 CODE;
 
 it('two line breaks separate methods', function() {
-	$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+	$parser = (new ParserFactory)->createForNewestSupportedVersion();
 	$prettyPrinter = new PSR2PrettyPrinter;
 
 	$stmts = $parser->parse(CODE);


### PR DESCRIPTION
This PR adds support for `nikic/php-parser` 5.0.
It removes support for 4.0.

This has become necessary as PHPUnit 11 requires 5.0. [PHPUnit 11 is now the default in Laravel](https://github.com/laravel/laravel/blob/b3df041d860233e3d1cd325fea41abe6564e894c/composer.json#L18).